### PR TITLE
BK-1383 Fetch latest python-ooxml from head of git repo

### DIFF
--- a/requirements/_base.txt
+++ b/requirements/_base.txt
@@ -10,4 +10,4 @@ redis
 pika
 unipath
 django-braces
-python-ooxml
+-e git+git://github.com/booktype/python-ooxml.git#egg=python-ooxml


### PR DESCRIPTION
During the beta stage of Booktype 2.0 it might be good to have the latest git version of python-ooxml rather than the last official release.