### PR TITLE
BK-1371 Convert scripts for EPUB production

### DIFF
--- a/lib/booktype/apps/edit/tasks.py
+++ b/lib/booktype/apps/edit/tasks.py
@@ -63,10 +63,10 @@ def publish_book(*args, **kwargs):
     book_url = "%s/%s/_export/" % (settings.BOOKTYPE_URL, book.url_title)
 
     data = {
-        "assets" : {
-            "input.epub" : book_url
+        "assets": {
+            "input.epub": book_url
         },
-        "input" : "input.epub",
+        "input": "input.epub",
         "outputs": {}
     }
 
@@ -75,19 +75,21 @@ def publish_book(*args, **kwargs):
         if _format == "epub":
             _ext = "epub"
 
-        data["outputs"][_format] = {"profile": _format,
+        data["outputs"][_format] = {
+            "profile": _format,
             "config": {
                 "project_id": book.url_title
-                },
+            },
             "output": "{}.{}".format(book.url_title, _ext)
-            }
+        }
 
     logger.debug(data)
 
     output_results = {}
-    #_format: False for _format in data["outputs"].iterkeys()}
+    # _format: False for _format in data["outputs"].iterkeys()}
 
-    result = fetch_url('{}/_convert/'.format(settings.BOOKTYPE_URL), data, method='POST')
+    result = fetch_url(
+        '{}/_convert/'.format(settings.BOOKTYPE_URL), data, method='POST')
 
     if not result:
         sputnik.addMessageToChannel2(
@@ -102,7 +104,7 @@ def publish_book(*args, **kwargs):
         )
         return
 
-    task_id = result['task_id']    
+    task_id = result['task_id']
     start_time = time.time()
 
     while True:
@@ -120,7 +122,8 @@ def publish_book(*args, **kwargs):
             break
 
         try:
-            response = urllib2.urlopen('{}/_convert/{}'.format(settings.BOOKTYPE_URL, task_id)).read()
+            response = urllib2.urlopen(
+                '{}/_convert/{}'.format(settings.BOOKTYPE_URL, task_id)).read()
         except (urllib2.HTTPError, urllib2.URLError, httplib.HTTPException):
             logger.error(
                 'Could not communicate with a server to fetch polling data.')
@@ -134,14 +137,13 @@ def publish_book(*args, **kwargs):
             dta = {'state': ''}
             logger.error('Could not parse JSON string.')
 
-        if dta['state'] == 'SUCCESS':   
+        if dta['state'] == 'SUCCESS':
             for _key in data["outputs"].iterkeys():
                 if 'state' in dta['result'][_key]:
                     if dta['result'][_key]['state'] == 'SUCCESS':
                         output_results[_key] = True
                     elif dta['result'][_key]['state'] == 'FAILURE':
                         output_results[_key] = False
-
 
             if len(output_results) == len(data["outputs"].keys()):
                 def _x(_key):
@@ -154,7 +156,7 @@ def publish_book(*args, **kwargs):
                 urls = {_key: _x(_key) for _key in output_results.iterkeys()}
 
                 _now = datetime.datetime.now()
-                
+
                 sputnik.addMessageToChannel2(
                     kwargs['clientid'],
                     kwargs['sputnikid'],
@@ -183,5 +185,3 @@ def publish_book(*args, **kwargs):
             break
 
         time.sleep(0.5)
-
-

--- a/lib/booktype/convert/epub/constants.py
+++ b/lib/booktype/convert/epub/constants.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+
+IMAGES_DIR = 'Images'
+STYLES_DIR = 'Styles'
+DOCUMENTS_DIR = 'Text'
+DEFAULT_LANG = 'en'
+
+EPUB_VALID_IMG_ATTRS = frozenset([
+    "alt", "class", "dir", "height", "id", "ismap", "longdesc",
+    "style", "title", "usemap", "width", "xml:lang", "src"
+])

--- a/lib/booktype/convert/epub/converter.py
+++ b/lib/booktype/convert/epub/converter.py
@@ -14,13 +14,283 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with Booktype.  If not, see <http://www.gnu.org/licenses/>.
 
-from ebooklib import epub
+import os
+import logging
+import urlparse
+import ebooklib
+
+from copy import deepcopy
+
 from ..base import BaseConverter
+from ..utils.epub import parse_toc_nav
+
+from .writer import Writer
+from .writerplugin import WriterPlugin
+from .cover import add_cover, COVER_FILE_NAME
+
+from .constants import (
+    IMAGES_DIR, STYLES_DIR,
+    DOCUMENTS_DIR, DEFAULT_LANG
+)
+
+logger = logging.getLogger("booktype.convert.epub")
+TOC_TITLE = 'toc'
+
 
 class EpubConverter(BaseConverter):
-    name = "epub"
+    name = 'epub'
 
-    def convert(self, book, output_path):
-        epub_writer = epub.EpubWriter(output_path, book)
+    DEFAULT_STYLE = 'style1'
+    css_dir = os.path.join(os.path.dirname(__file__), 'styles/')
+
+    def convert(self, original_book, output_path):
+        logger.debug('[EPUB] EpubConverter.convert')
+
+        epub_book = ebooklib.epub.EpubBook()
+        epub_book.FOLDER_NAME = 'OEBPS'
+
+        epub_book.uid = original_book.uid
+        epub_book.title = original_book.title
+        epub_book.metadata = deepcopy(original_book.metadata)
+        epub_book.toc = []
+
+        logger.debug('[EPUB] Edit metadata')
+        self._edit_metadata(epub_book)
+
+        logger.debug('[EPUB] Copy items')
+        self._copy_items(epub_book, original_book)
+
+        logger.debug('[EPUB] Make navigation')
+        self._make_nav(epub_book, original_book)
+
+        logger.debug('[EPUB] Add cover')
+        self._add_cover(epub_book)
+
+        logger.debug('[EPUB] Writer plugin')
+
+        writer_plugin = WriterPlugin()
+        writer_plugin.options['style'] = self.config.get(
+            'style', self.DEFAULT_STYLE)
+
+        writer_plugin.options['lang'] = self.config.get('lang', DEFAULT_LANG)
+        writer_plugin.options['preview'] = self.config.get('preview', True)
+
+        logger.debug('[EPUB] Adding default and custom css')
+        book_css = self._add_css_styles(epub_book)
+        writer_plugin.options['css'] = book_css
+
+        if self.config.get('lang', DEFAULT_LANG) == 'ar':
+            rtl_css = self._rtl_style(epub_book)
+
+            if rtl_css:
+                writer_plugin.options['css'].append(rtl_css)
+
+        writer_options = {
+            'plugins': [writer_plugin, ]
+        }
+
+        logger.debug('[EPUB] Writer')
+        epub_writer = Writer(
+            output_path, epub_book, options=writer_options)
+
+        logger.debug('[EPUB] Process')
         epub_writer.process()
+
+        logger.debug('[EPUB] Write')
         epub_writer.write()
+
+        logger.debug('[END] EPUBConverter.convert')
+
+    def _edit_metadata(self, epub_book):
+        """
+        Modifies original metadata.
+        """
+
+        # delete existing 'modified' tag
+        m = epub_book.metadata[ebooklib.epub.NAMESPACES["OPF"]]
+        m[None] = filter(lambda (_,x): not (isinstance(x, dict) and x.get("property") == "dcterms:modified"), m[None]) # noqa
+
+        # NOTE: probably going to extend this function in future
+
+    def _make_nav(self, epub_book, original_book):
+        """
+        Creates navigational stuff (guide, ncx, nav) by copying the original.
+        """
+
+        # maps TOC items to sections and links
+        self._num_of_text = 0
+
+        def mapper(toc_item):
+            add_to_guide = True
+
+            if isinstance(toc_item[1], list):
+                section_title, chapters = toc_item
+
+                section = ebooklib.epub.Section(section_title)
+                links = map(mapper, chapters)
+
+                return (section, links)
+            else:
+                chapter_title, chapter_href = toc_item
+
+                chapter_href = "{}/{}".format(DOCUMENTS_DIR, chapter_href)
+                chapter_path = urlparse.urlparse(chapter_href).path
+
+                book_item = self.items_by_path[chapter_path]
+                book_item.title = chapter_title
+
+                if self._num_of_text > 0:
+                    add_to_guide = False
+
+                self._num_of_text += 1
+
+                if add_to_guide:
+                    epub_book.guide.append({
+                        'type': 'text',
+                        'href': chapter_href,
+                        'title': chapter_title,
+                    })
+
+                return ebooklib.epub.Link(
+                    href=chapter_href, title=chapter_title, uid=book_item.id)
+
+        # filters-out empty sections
+        def _empty_sec(item):
+            if isinstance(item, tuple) and len(item[1]) == 0:
+                return False
+            else:
+                return True
+
+        # filters-out existing cover
+        def _skip_cover(item):
+            if os.path.basename(item[1]) == COVER_FILE_NAME:
+                return False
+            return True
+
+        toc = filter(_skip_cover, parse_toc_nav(original_book))
+        toc = map(mapper, toc)
+        toc = filter(_empty_sec, toc)
+
+        epub_book.toc = toc
+
+    def _copy_items(self, epub_book, original_book):
+        """
+        Populates the book by copying items from the original book
+        """
+        self.items_by_path = {}
+
+        for orig_item in original_book.items:
+            item = deepcopy(orig_item)
+            item_type = item.get_type()
+            file_name = os.path.basename(item.file_name)
+
+            # do not copy cover
+            if self._is_cover_item(item):
+                continue
+
+            if item_type == ebooklib.ITEM_IMAGE:
+                item.file_name = '{}/{}'.format(IMAGES_DIR, file_name)
+
+            elif item_type == ebooklib.ITEM_STYLE:
+                item.file_name = '{}/{}'.format(STYLES_DIR, file_name)
+
+            elif item_type == ebooklib.ITEM_DOCUMENT:
+                item.file_name = '{}/{}'.format(DOCUMENTS_DIR, file_name)
+                if isinstance(item, ebooklib.epub.EpubNav):
+                    epub_book.spine.insert(0, item)
+                    epub_book.guide.insert(0, {
+                        'type': 'toc',
+                        'href': item.file_name,
+                        'title': self.config.get('toc_title', TOC_TITLE)
+                    })
+                else:
+                    epub_book.spine.append(item)
+
+            if isinstance(item, ebooklib.epub.EpubNcx):
+                item = ebooklib.epub.EpubNcx()
+
+            epub_book.add_item(item)
+            self.items_by_path[item.file_name] = item
+
+    def _add_cover(self, epub_book):
+        """
+        Adds cover image if present in config to the resulting EPUB
+        """
+
+        if 'cover_image' in self.config.keys():
+            cover_asset = self.get_asset(self.config['cover_image'])
+            add_cover(
+                epub_book, cover_asset, self.config.get('lang', DEFAULT_LANG))
+
+    def _add_css_styles(self, epub_book):
+        """
+        Adds default css styles and custom css text if exists in config
+        """
+
+        book_css = []
+
+        try:
+            content = open(
+                '{}/default.css'.format(self.css_dir), 'rt').read()
+
+            item = ebooklib.epub.EpubItem(
+                uid='default.css',
+                content=content,
+                file_name='{}/{}'.format(STYLES_DIR, 'default.css'),
+                media_type='text/css'
+            )
+
+            epub_book.add_item(item)
+            book_css.append('default.css')
+        except:
+            pass
+
+        # time to add custom css :)
+        if 'css_text' in self.config.keys():
+            item = ebooklib.epub.EpubItem(
+                uid='custom.css',
+                content=self.config.get('css_text'),
+                file_name='{}/{}'.format(STYLES_DIR, 'custom.css'),
+                media_type='text/css'
+            )
+
+            epub_book.add_item(item)
+            book_css.append('custom.css')
+
+        return book_css
+
+    def _rtl_style(self, epub_book):
+        """
+        Set rtl css style to the EPUB book
+        """
+
+        try:
+            content = open(
+                '{}/style-rtl.css'.format(self.css_dir), 'rt').read()
+
+            item = ebooklib.epub.EpubItem(
+                uid='style-rtl.css',
+                content=content,
+                file_name='{}/{}'.format(STYLES_DIR, 'style-rtl.css'),
+                media_type='text/css'
+            )
+
+            epub_book.add_item(item)
+            return 'style-rtl.css'
+        except:
+            return None
+
+    def _is_cover_item(self, item):
+        """
+        Determines if an given item is cover type
+        """
+
+        file_name = os.path.basename(item.file_name)
+
+        cover_types = [
+            ebooklib.epub.EpubCover,
+            ebooklib.epub.EpubCoverHtml
+        ]
+
+        return (
+            type(item) in cover_types or file_name == 'cover.xhtml')

--- a/lib/booktype/convert/epub/cover.py
+++ b/lib/booktype/convert/epub/cover.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+from ebooklib import epub
+
+from .constants import (
+    DOCUMENTS_DIR,
+    IMAGES_DIR
+)
+
+
+COVER_XML = """
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>%(book_title)s</title>
+    </head>
+    <body id="template" xml:lang="%(language)s" style="margin:0px; text-align: center; vertical-align: middle; background-color:#fff;">
+        <div>
+            <img src="%(cover_path)s" style="height:100%%; text-align:center"/>
+        </div>
+    </body>
+</html>
+"""
+
+COVER_UID = 'cover'
+COVER_TITLE = 'Cover'
+COVER_FILE_NAME = 'cover.xhtml'
+
+IMAGE_UID = 'cover_image'
+IMAGE_FILE_NAME = 'cover.jpg'
+
+
+def add_cover(epub_book, cover_asset, language='en', cover_title=COVER_TITLE):
+    """
+    Adds cover image to the given book
+    """
+
+    cover_path = '../{}/{}'.format(IMAGES_DIR, IMAGE_FILE_NAME)
+    cover_data = {
+        'book_title': epub_book.title,
+        'language': language,
+        'cover_path': cover_path
+    }
+    item = epub.EpubHtml(
+        uid=COVER_UID,
+        title=cover_title,
+        file_name='{}/{}'.format(DOCUMENTS_DIR, COVER_FILE_NAME),
+        content=COVER_XML % cover_data
+    )
+
+    epub_book.add_item(item)
+    epub_book.spine.insert(0, item)
+
+    epub_book.guide.insert(0, {
+        'type': 'cover',
+        'href': '{}/{}'.format(DOCUMENTS_DIR, COVER_FILE_NAME),
+        'title': item.title,
+    })
+
+    image_file = open(cover_asset.file_path, 'rb')
+
+    image = epub.EpubCover()
+    image.id = IMAGE_UID
+    image.file_name = '{}/{}'.format(IMAGES_DIR, IMAGE_FILE_NAME)
+    image.set_content(image_file.read())
+
+    epub_book.add_item(image)
+
+    image_file.close()
+
+    epub_book.add_metadata(
+        None, 'meta', '', {
+            'name': 'cover',
+            'content': IMAGE_UID
+        }
+    )

--- a/lib/booktype/convert/epub/displayoptions.py
+++ b/lib/booktype/convert/epub/displayoptions.py
@@ -1,0 +1,20 @@
+
+XML_TEXT = """<?xml version="1.0" encoding="UTF-8"?>
+<display_options>
+<platform name="*">
+<option name="specified-fonts">%(specified_fonts)s</option>
+</platform>
+</display_options>"""
+
+DEFAULT_OPTIONS = {
+    "specified_fonts": "true",
+}
+
+
+def make_display_options_xml(**kwargs):
+    options = DEFAULT_OPTIONS
+
+    if kwargs.get("specified_fonts"):
+        options["specified_fonts"] = "true"
+
+    return XML_TEXT % options

--- a/lib/booktype/convert/epub/styles/style-rtl.css
+++ b/lib/booktype/convert/epub/styles/style-rtl.css
@@ -1,0 +1,5 @@
+body, p, div {
+  direction: rtl;
+  unicode-bidi: embed;
+  text-align: right;
+}

--- a/lib/booktype/convert/epub/writer.py
+++ b/lib/booktype/convert/epub/writer.py
@@ -1,0 +1,43 @@
+import os
+import urllib
+import ebooklib
+
+from lxml import etree
+from ebooklib.epub import NAMESPACES
+
+from .constants import DOCUMENTS_DIR
+from .displayoptions import make_display_options_xml
+
+
+class Writer(ebooklib.epub.EpubWriter):
+
+    def _fix_nav_links(self, content):
+        """
+        Fix the path of the links in nav file
+        """
+
+        root = ebooklib.utils.parse_string(content)
+        for element in root.iter('{%s}a' % NAMESPACES['XHTML']):
+            href = urllib.unquote(element.get('href'))
+
+            if href.startswith(DOCUMENTS_DIR):
+                file_name = os.path.basename(href)
+                element.set(
+                    'href', '../{}/{}'.format(DOCUMENTS_DIR, file_name))
+
+        content = etree.tostring(
+            root, pretty_print=True, encoding='utf-8', xml_declaration=True)
+        return content
+
+    def _get_nav(self, item):
+        content = super(Writer, self)._get_nav(item)
+        return self._fix_nav_links(content)
+
+    def _write_container(self):
+        super(Writer, self)._write_container()
+
+        display_options_xml = make_display_options_xml(**self.options)
+        self.out.writestr(
+            "META-INF/com.apple.ibooks.display-options.xml",
+            display_options_xml
+        )

--- a/lib/booktype/convert/epub/writerplugin.py
+++ b/lib/booktype/convert/epub/writerplugin.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+import os
+import urllib
+import urlparse
+import ebooklib
+
+from lxml import etree
+from ebooklib.plugins.base import BasePlugin
+
+from .constants import (
+    STYLES_DIR, IMAGES_DIR,
+    DEFAULT_LANG, EPUB_VALID_IMG_ATTRS
+)
+
+
+class WriterPlugin(BasePlugin):
+    """
+    Basic plugin for Booktype EPUB Writing
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(WriterPlugin, self).__init__(*args, **kwargs)
+        self.options = {}
+
+    def html_before_write(self, book, item):
+        if item.get_type() != ebooklib.ITEM_DOCUMENT:
+            return True
+
+        for css_file in self.options.get('css', []):
+            item.add_link(
+                href='../{}/{}'.format(STYLES_DIR, css_file),
+                rel='stylesheet', type='text/css')
+
+        if isinstance(item, ebooklib.epub.EpubNav):
+            return True
+
+        item.lang = self.options.get('lang', DEFAULT_LANG)
+
+        root = ebooklib.utils.parse_html_string(item.content)
+        self._fix_images(root)
+
+        item.content = etree.tostring(
+            root, pretty_print=True, encoding="utf-8", xml_declaration=True)
+
+        return True
+
+    def _fix_images(self, root):
+        """
+        Fix the path of the images to match with IMAGES_DIR
+        """
+
+        for element in root.iter('img'):
+
+            path = urllib.unquote(element.get('src'))
+
+            # if hostname, then it is an image with absolute url
+            if urlparse.urlparse(path).hostname:
+                continue
+
+            try:
+                path = path.decode('utf-8')
+            except:
+                pass
+
+            file_name = os.path.basename(path)
+            element.set('src', "../{}/{}".format(IMAGES_DIR, file_name))
+
+            # remove not allowed attributes from image element
+            for attr in frozenset(element.keys()) - EPUB_VALID_IMG_ATTRS:
+                del element.attrib[attr]
+
+            # make sure the alt attribute is valid
+            alt = element.get('alt')
+            not_valid = ['none', 'nothing', 'image']
+
+            if (alt is None) or alt in not_valid:
+                element.set('alt', '')


### PR DESCRIPTION
There is one problem with this. Epub Checker throws some reference errors on NCX file. 
nav.xhtml has paths to chapters that are in the same folder ( Text/ ) but the problem is that toc.ncx file generation use the same items that nav generation, but... toc.ncx is outside of Text/ folder so the reference links that it has are wrong. Those links need to be fixed to be something like Text/chapter.html instead of only chapter.html.

I tried many different way but at the end both toc.ncx and nav.xhtml are generated in write function of EpubWriter. We need to patch ebooklib to be able to have optional basepath for toc.ncx generation.

talk later