### PR TITLE
BK-1400 Dev profile should enable debug logging

### DIFF
--- a/lib/booktype/skeleton/dev_settings.py.original
+++ b/lib/booktype/skeleton/dev_settings.py.original
@@ -109,7 +109,7 @@ LOGGING = {
         },
         'booktype': {
             'handlers': ['logfile'],
-            'level': 'INFO'
+            'level': 'DEBUG'
         }
     }
 }


### PR DESCRIPTION
Otherwise instance file logs/booktype.log is empty when debugging.