### PR TITLE
BK-1405 Add mPDF stanzas to dev and prod profile skeletons

### DIFF
--- a/lib/booktype/skeleton/dev_settings.py.original
+++ b/lib/booktype/skeleton/dev_settings.py.original
@@ -10,6 +10,12 @@ STATIC_URL  = '{}/static/'.format(BOOKTYPE_URL)
 DATA_URL  = '{}/data/'.format(BOOKTYPE_URL)
 MEDIA_URL = DATA_URL
 
+# MPDF RENDERER SETTINGS
+
+MPDF_DIR = ''
+PHP_PATH = '/usr/bin/php'
+MPDF_SCRIPT = '' 
+
 # DEBUGGING
 DEBUG = TEMPLATE_DEBUG = True
 

--- a/lib/booktype/skeleton/prod_settings.py.original
+++ b/lib/booktype/skeleton/prod_settings.py.original
@@ -10,6 +10,12 @@ STATIC_URL  = '{}/static/'.format(BOOKTYPE_URL)
 DATA_URL  = '{}/data/'.format(BOOKTYPE_URL)
 MEDIA_URL = DATA_URL
 
+# MPDF RENDERER SETTINGS
+
+MPDF_DIR = ''
+PHP_PATH = '/usr/bin/php'
+MPDF_SCRIPT = '' 
+
 # DEBUG
 DEBUG = TEMPLATE_DEBUG = False
 


### PR DESCRIPTION
Useful so that profiles can use different renderers, for example mPDF 5.7 versus 6.0.