### PR TITLE
BK-1416 Bug when section has the same toc.id as chapter instance in one ...

### DIFF
--- a/lib/booktype/apps/edit/static/edit/js/booktype/toc.js
+++ b/lib/booktype/apps/edit/static/edit/js/booktype/toc.js
@@ -178,7 +178,9 @@
       },
 
       getItemWithChapterID: function (cid) {
-        return _.find(this.chapters, function (elem) { return elem.get("chapterID") === parseInt(cid, radix); });
+        return _.find(this.chapters, function (elem) {
+          return elem.get("chapterID") === parseInt(cid, radix) && elem.get("isSection") !== true;
+        });
       },
 
       addChapter: function (chap) {
@@ -1036,14 +1038,7 @@
             },
 
             "chapter_lock_changed": function () {
-              // TODO use TOC method in future.
-              // now issue that tocID can be identical to chapterID
-
-              //var item = win.booktype.editor.data.chapters.getItemWithChapterID(message.chapterID);
-              var item = _.find(win.booktype.editor.data.chapters.chapters,
-                function (elem) {
-                  return elem.get("chapterID") === parseInt(message.chapterID, radix) && elem.get("isSection") !== true;
-                });
+              var item = win.booktype.editor.data.chapters.getItemWithChapterID(message.chapterID);
 
               item.set("lockType", message.lockType);
               if (win.booktype.editor.getActivePanel().name !== "toc") { return; }


### PR DESCRIPTION
BK-1416 Bug when section has the same toc.id as chapter instance in one editor

Method "getItemWithChapterID" used for working only with chapters (not sections),
for retrieving sections using method "getTocItemWithID" which uses "tocID" key.