### PR TITLE
BK-1487 Chapters unhold into deleted section.

### DIFF
--- a/lib/booktype/apps/edit/static/edit/js/booktype/toc.js
+++ b/lib/booktype/apps/edit/static/edit/js/booktype/toc.js
@@ -1027,6 +1027,9 @@
                 tocWidget.removeItem(chap);
               }
 
+              // for now after unhold chapters should display in the end of toc root
+              chap.set("parentID", "root");
+
               win.booktype.editor.data.holdChapters.addChapter(chap);
               win.booktype.editor.data.chapters.removeItem(message.chapterID);
 


### PR DESCRIPTION
Discussed it with Julian, for now all chapters after unhold are displaying in the end of toc in root. This is server logic and it works.
After unhold we should display all chapters in the end of toc root.