### PR TITLE
BK-1462 When using direct link chapter editor should be disabled when user does not have permissions to edit it

### DIFF
--- a/lib/booktype/apps/edit/static/edit/js/booktype/editor.js
+++ b/lib/booktype/apps/edit/static/edit/js/booktype/editor.js
@@ -356,6 +356,14 @@
           'edit_lock': true
         },
         function (dta) {
+
+          if (!dta.access) {
+            alert(dta.reason);
+            router.navigate('toc', true);
+            win.booktype.ui.notify();
+            return;
+          }
+
           currentEdit = id;
 
           var activePanel = win.booktype.editor.getActivePanel();


### PR DESCRIPTION
Squashed:
BK-1462 Update get_chapter channel. Update some permissions in channels from lock_chapter to edit_locked_chapter
and
BK-1462 When using direct link chapter editor should be disabled when user does not have permissions to edit it