### PR TITLE
BK-1512 Bootstrap popup message after edit was terminated.

### DIFF
--- a/lib/booktype/apps/edit/static/edit/js/booktype/editor.js
+++ b/lib/booktype/apps/edit/static/edit/js/booktype/editor.js
@@ -379,7 +379,14 @@
                       Aloha.jQuery('#contenteditor').mahalo();
                       Backbone.history.navigate('toc', true);
                       jquery('#button-toc').parent().addClass('active');
-                      alert(win.booktype._('terminate_editing_by_book_admin', 'Editing was terminated by book administrator.'));
+
+                      // info popup
+                      var renderedModalInfoPopup = _.template(jquery('#modalInfoPopup').html())({
+                        "header": win.booktype._('editing_terminated', 'Editing terminated.'),
+                        "body": win.booktype._('terminate_editing_by_book_admin', 'Editing was terminated by book administrator.')
+                      });
+                      var modalInfoPopup = jquery(jquery.trim(renderedModalInfoPopup));
+                      modalInfoPopup.modal("show");
                     }
                     setTimeout(_sendNotification, 5000);
                   }

--- a/lib/booktype/apps/edit/templates/edit/edit_strings.html
+++ b/lib/booktype/apps/edit/templates/edit/edit_strings.html
@@ -46,4 +46,5 @@
   <li data-translace-id="terminate_editing">{% trans "Terminate editing" %}</li>
   <li data-translace-id="terminate_editing_by_book_admin">{% trans "Editing was terminated by book administrator." %}</li>
   <li data-translace-id="invite_sent">{% trans "You invitation has been sent" %}</li>
+  <li data-translace-id="editing_terminated">{% trans "Editing terminated." %}</li>
 </ul>

--- a/lib/booktype/apps/edit/templates/edit/panel_toc.html
+++ b/lib/booktype/apps/edit/templates/edit/panel_toc.html
@@ -417,3 +417,22 @@
   <ol>
   </ol>
 </li>
+
+<script type="text/html" id="modalInfoPopup">
+    <div class="modal fade" tabindex="-1" role="dialog">
+     <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
+          <h3><%= header %></h3>
+        </div>
+        <div class="modal-body">
+          <%= body %>
+        </div>
+        <div class="modal-footer">
+          <button class="btn btn-default" data-dismiss="modal" aria-hidden="true">{% trans "Close" %}</button>
+        </div>
+       </div>
+     </div>
+    </div>
+</script>


### PR DESCRIPTION
I've rendered template content on server side (except close button text).
I think in future we can simply reuse this template for other info-modals.
I have not safari and it's a dirty install procedure for linux, if you can, please, test it with safari. 