### PR TITLE
BK-1621 Exported filenames could contain timestamp

### DIFF
--- a/lib/booktype/apps/edit/tasks.py
+++ b/lib/booktype/apps/edit/tasks.py
@@ -118,7 +118,7 @@ def publish_book(*args, **kwargs):
                 "settings": format_settings,
                 "theme": get_theme(book, kwargs["username"])
             },
-            "output": "{}.{}".format(book.url_title, _ext)
+            "output": "{0}_{1}.{2}".format(book.url_title, datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S'), _ext)
         }
 
         if 'cover_image' in format_settings:


### PR DESCRIPTION
I've changed format to: "bookname-2015-08-17-12-25-14.pdf" due to sign ":" is reserved sign for some operation systems, including ms windows.