### PR TITLE
BK-1674 Strange behavior in undo plugin in case of fast typing with enabled tracking

### DIFF
--- a/lib/booktype/apps/edit/static/edit/js/aloha/plugins/booktype/bookundo/lib/bookundo-plugin.js
+++ b/lib/booktype/apps/edit/static/edit/js/aloha/plugins/booktype/bookundo/lib/bookundo-plugin.js
@@ -235,6 +235,14 @@ define(
           return;
         }
 
+        // we call doCleanup on almost every keydown
+        // to prevent async range changing in case fast typing
+        var rangeObject = Aloha.Selection.getRangeObject();
+        if (GENTICS.Utils.Dom.doCleanup({'merge': true}, rangeObject, rangeObject.getCommonAncestorContainer())) {
+          rangeObject.update();
+          rangeObject.select();
+        }
+
         // to start stack with current position if we start typing after redo/undo
         if (undoFlag === true) {
           stack_length = current_stack_position;


### PR DESCRIPTION
Regarding redo issue which was mentioned in amnesty bug report. Redo function was implemented.
To use redo we should open edit menu and click redo, or use hot keys "cmnd + shift + z" for mac and "ctrl + shift + z" for windows/linux.