### PR TITLE
BK-1681 Consistent use of 'Accept changes'

### DIFF
--- a/lib/booktype/apps/edit/__init__.py
+++ b/lib/booktype/apps/edit/__init__.py
@@ -34,7 +34,7 @@ PERMISSIONS = {
         ('note_edit', _('Edit Notes')),
 
         ('track_changes', _('Track Changes')),
-        ('track_changes_approve', _('Track Changes approve/decline')),
+        ('track_changes_approve', _('Track Changes accept/decline')),
         ('track_changes_enable', _('Track Changes on/off')),
 
         # permissions for settings interface

--- a/lib/booktype/locale/en/LC_MESSAGES/django.po
+++ b/lib/booktype/locale/en/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Booktype 2.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-09-16 11:34+0100\n"
+"POT-Creation-Date: 2015-09-28 12:37+0100\n"
 "PO-Revision-Date: 2015-05-15 11:52+0100\n"
 "Last-Translator: Daniel James <daniel.james@sourcefabric.org>\n"
 "Language-Team: Sourcefabric Localization <contact@sourcefabric.org>\n"
@@ -1088,7 +1088,7 @@ msgid "Track Changes"
 msgstr ""
 
 #: apps/edit/__init__.py:37
-msgid "Track Changes approve/decline"
+msgid "Track Changes accept/decline"
 msgstr ""
 
 #: apps/edit/__init__.py:38
@@ -1206,12 +1206,12 @@ msgstr ""
 msgid "Book History"
 msgstr ""
 
-#: apps/edit/views.py:554 apps/edit/templates/edit/_compare_modal.html:7
+#: apps/edit/views.py:562 apps/edit/templates/edit/_compare_modal.html:7
 #: apps/edit/templates/edit/compare_screen.html:13
 msgid "Chapter diff"
 msgstr ""
 
-#: apps/edit/views.py:585 apps/edit/templates/edit/_compare_modal.html:16
+#: apps/edit/views.py:593 apps/edit/templates/edit/_compare_modal.html:16
 #: apps/edit/templates/edit/_compare_modal.html:17
 #: apps/edit/templates/edit/chapter_history.html:23
 #: apps/edit/templates/edit/chapter_revision.html:16
@@ -1220,32 +1220,32 @@ msgstr ""
 msgid "Revision"
 msgstr ""
 
-#: apps/edit/views.py:592
+#: apps/edit/views.py:600
 msgid "Book History | Chapter Revision"
 msgstr ""
 
-#: apps/edit/views.py:615
+#: apps/edit/views.py:623
 #, python-format
 msgid "Reverted to revision %s."
 msgstr ""
 
-#: apps/edit/views.py:634
+#: apps/edit/views.py:642
 msgid "Chapter revision successfully reverted."
 msgstr ""
 
-#: apps/edit/views.py:636
+#: apps/edit/views.py:644
 msgid "Chapter revision could not be reverted."
 msgstr ""
 
-#: apps/edit/views.py:705
+#: apps/edit/views.py:713
 msgid "Successfully saved settings."
 msgstr ""
 
-#: apps/edit/views.py:707
+#: apps/edit/views.py:715
 msgid "You have no permissions to execute this action."
 msgstr ""
 
-#: apps/edit/views.py:710
+#: apps/edit/views.py:718
 msgid "Unknown error while saving changes."
 msgstr ""
 


### PR DESCRIPTION
Just so this checkbox matches the button label in the editor. 'Approve' is not the exact opposite of 'Decline'.