### PR TITLE
BK-1682 Hide redundant slider tooltips, fix left margin for sliders

### DIFF
--- a/lib/booktype/apps/edit/static/edit/css/slider.css
+++ b/lib/booktype/apps/edit/static/edit/css/slider.css
@@ -14,7 +14,7 @@
 .slider.slider-horizontal {
   width: 210px;
   height: 20px;
-  /*margin-left:3px;*/
+  margin-left: 10px;
 }
 .slider.slider-horizontal .slider-track {
   height: 6px;

--- a/lib/booktype/apps/themes/templates/themes/panel.html
+++ b/lib/booktype/apps/themes/templates/themes/panel.html
@@ -12,7 +12,7 @@
        </select>
      </div>
 
-     <div class="col-md-3 col-md-offset-1 reset-button">
+     <div class="col-md-3 reset-button">
         <button class="btn btn-info">{% trans "reset" %}</button>
      </div>
    </div>

--- a/lib/booktype/skeleton/themes/custom/panel.html
+++ b/lib/booktype/skeleton/themes/custom/panel.html
@@ -23,7 +23,7 @@
     </div>
     <div class="row">
       <div class="col-md-9">
-        <input type="text" class="heading-size" value="" data-slider-min="100" data-slider-max="300" data-slider-step="10" data-slider-value="160" data-slider-orientation="horizontal" data-slider-selection="after" data-slider-tooltip="show"  style="width: 200px;">
+        <input type="text" class="heading-size" data-slider-min="100" data-slider-max="300" data-slider-step="5" data-slider-value="160" data-slider-orientation="horizontal" data-slider-selection="after" data-slider-tooltip="hide"  style="width: 200px;">
       </div>
       <div class="col-md-1 heading-view-size"></div>
     </div>
@@ -79,7 +79,7 @@
       </div>
       <div class="row">
         <div class="col-md-9">
-          <input type="text" class="paragraph-indent" value="" data-slider-min="0" data-slider-max="5" data-slider-step="0.10" data-slider-value="0" data-slider-orientation="horizontal" data-slider-selection="after" data-slider-tooltip="show" style="width: 200px;">
+          <input type="text" class="paragraph-indent" data-slider-min="0" data-slider-max="5" data-slider-step="0.05" data-slider-value="0" data-slider-orientation="horizontal" data-slider-selection="after" data-slider-tooltip="hide" style="width: 200px;">
         </div>
         <div class="col-md-1 paragraph-view-indent"></div>
       </div>
@@ -91,7 +91,7 @@
       </div>
       <div class="row">
         <div class="col-md-9">
-          <input type="text" class="paragraph-line-height"  value="" data-slider-min="100" data-slider-max="200" data-slider-step="5" data-slider-value="100" data-slider-orientation="horizontal" data-slider-selection="after" data-slider-tooltip="show" style="width: 200px;">
+          <input type="text" class="paragraph-line-height" data-slider-min="100" data-slider-max="200" data-slider-step="5" data-slider-value="130" data-slider-orientation="horizontal" data-slider-selection="after" data-slider-tooltip="hide" style="width: 200px;">
         </div>
         <div class="col-md-1 paragraph-view-line-height"></div>
       </div>


### PR DESCRIPTION
Tooltips on these sliders have a precision bug, and we don't need the tooltips because the value of the slider is shown immediately to the right anyhow. Least intrusive solution is just to hide these particular tooltips. Also put the left margin back in place for the sliders, so that the full handle can be seen when the value is at minimum. 

Other enhancements are to allow 5% precision for sliders instead of 10%, and set a default for custom style line height of 130% instead of 100%.