### PR TITLE
BK-1659 Fix language code for Great Britain, add other new languages

### DIFF
--- a/lib/booktype/skeleton/base_settings.py.original
+++ b/lib/booktype/skeleton/base_settings.py.original
@@ -136,16 +136,24 @@ LANGUAGE_CODE = 'en-us'
 gettext = lambda s: s
 
 LANGUAGES = (
+   ('en', gettext('American English')),
+   ('en-gb', gettext('British English')),
+   ('ca', gettext('Català')),
    ('de', gettext('Deutsch')),
-   ('en_GB', gettext('English (United Kingdom)')),
-   ('en', gettext('English (United States)')),
+   ('de-at', gettext('Österreichisches Deutsch')),
+   ('el', gettext('Ελληνικά')),
    ('es', gettext('Español')),
    ('fr', gettext('Français')),
    ('it', gettext('Italiano')),
    ('hu', gettext('Magyar')),
+   ('nl', gettext('Nederlands')),
+   ('no', gettext('Norwegian')),
+   ('pl', gettext('Polski')),
    ('pt', gettext('Português')),
    ('ru', gettext('Русский')),
-   ('sq', gettext('Shqip')),
+   ('sq', gettext('Shqipe')),
+   ('fi', gettext('Suomi')),
+   ('tr', gettext('Türkçe')),
 )
 
 SITE_ID = 1


### PR DESCRIPTION
So it turns out the reason British localization wasn't working was that I used the underscore form of the language code, when I should have used the hyphenated form.

Also we have a bunch of new languages from Transifex to add.