### PR TITLE
BK-1673 Hide Publishing Defaults page from the Control Centre

### DIFF
--- a/lib/booktypecontrol/templates/booktypecontrol/control_center_settings.html
+++ b/lib/booktypecontrol/templates/booktypecontrol/control_center_settings.html
@@ -32,7 +32,6 @@
                         <li><a href="#default-roles" data-toggle="tab">{% trans "Default Roles" %}</a></li>
                         <li><a href="#privacy" data-toggle="tab">{% trans "Privacy" %}</a></li>
                         <li><a href="#publishing" data-toggle="tab">{% trans "Publishing Options" %}</a></li>
-                        <li><a href="#publishing-defaults" data-toggle="tab">{% trans "Publishing Defaults" %}</a></li>
 
                         <h4 data-menu="people">{% trans "People" %}</h4>
                         <li><a href="#add-person" data-toggle="tab">{% trans "Add a New Person" %}</a></li>


### PR DESCRIPTION
This page doesn't do anything now. In the short term, just hide it from instance admins.