### PR TITLE
BK-1640 Disambiguate PDF button, update translation strings

### DIFF
--- a/lib/booktype/apps/edit/templates/edit/panel_publish.html
+++ b/lib/booktype/apps/edit/templates/edit/panel_publish.html
@@ -401,7 +401,7 @@
         {% if "mpdf" in publish_options %}
           <div class="checkbox">
             <label>
-              <input name="mpdf" type="checkbox"> {% trans "Book PDF" %}
+              <input name="mpdf" type="checkbox"> {% trans "Printers' PDF" %}
             </label>
             {% check_perm 'export.export_settings' %}
               <a href="" data-settings="book" class="modal-open">{% trans "settings" %}</a>

--- a/lib/booktype/locale/en/LC_MESSAGES/django.po
+++ b/lib/booktype/locale/en/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Booktype 2.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-10-02 12:52+0100\n"
+"POT-Creation-Date: 2015-10-02 15:30+0100\n"
 "PO-Revision-Date: 2015-05-15 11:52+0100\n"
 "Last-Translator: Daniel James <daniel.james@sourcefabric.org>\n"
 "Language-Team: Sourcefabric Localization <contact@sourcefabric.org>\n"
@@ -2784,7 +2784,7 @@ msgid "No available publish formats."
 msgstr ""
 
 #: apps/edit/templates/edit/panel_publish.html:404
-msgid "Book PDF"
+msgid "Printers' PDF"
 msgstr ""
 
 #: apps/edit/templates/edit/panel_publish.html:407
@@ -3717,6 +3717,11 @@ msgstr ""
 msgid "Using {} as cover image"
 msgstr ""
 
+#: skeleton/themes/academic/panel.html:6
+msgid ""
+"This academic style is based on serif fonts for headings and paragraphs."
+msgstr ""
+
 #. Translators: User defined style Heading font
 #. Translators: User defined style Paragraph font
 #: skeleton/themes/custom/panel.html:9 skeleton/themes/custom/panel.html:68
@@ -3762,4 +3767,15 @@ msgstr ""
 #. Translators: User defined style settings
 #: skeleton/themes/custom/panel.html:89
 msgid "Line Height"
+msgstr ""
+
+#: skeleton/themes/simple/panel.html:6
+msgid ""
+"This simple style is based on sans-serif fonts for headings and paragraphs."
+msgstr ""
+
+#: skeleton/themes/simple2/panel.html:6
+msgid ""
+"This simple style is based on sans-serif fonts, with chapter headings "
+"underlined."
 msgstr ""


### PR DESCRIPTION
I thought we should make this 'Printers' PDF' because 'Print PDF' might be taken literally, as in 'click this button to print PDF'.