### PR TITLE
BK-1788 Remove trailing space after bracket

### DIFF
--- a/lib/booktype/convert/mpdf/converter.py
+++ b/lib/booktype/convert/mpdf/converter.py
@@ -546,7 +546,7 @@ class MPDFConverter(BaseConverter):
         for link in content.iter('a'):
             if link.attrib.get('href', '') != '':
                 text = link.tail or ''
-                link.tail = ' [' + link.attrib.get('href', '') + '] ' + text
+                link.tail = ' [' + link.attrib.get('href', '') + ']' + text
                 link.tag = 'span'
 
     def _fix_content(self, content):


### PR DESCRIPTION
This fix works for URLs in sentences where punctuation follows the link, and also where a normal space follows the link.