### PR TITLE
BK-1804 Make English strings for log in and log out consistent

### DIFF
--- a/lib/booktype/apps/account/templates/account/form_signin.html
+++ b/lib/booktype/apps/account/templates/account/form_signin.html
@@ -1,6 +1,6 @@
 {% load i18n  %}
 
-<h2 class="box-title">{% trans "Sign in" %}</h2>  
+<h2 class="box-title">{% trans "Log in" %}</h2>  
 
 <form id="formsignin" signin-href="{% url "accounts:signin" %}" redirect-href="{{ redirect|escapejs }}" class="form-group" onsubmit="return false;" action="#" method="GET">{% csrf_token %}
   <div class="form-group">

--- a/lib/booktype/apps/account/views.py
+++ b/lib/booktype/apps/account/views.py
@@ -439,8 +439,8 @@ class ForgotPasswordEnterView(PageView):
 
 class SignInView(PageView):
     template_name = "account/register.html"
-    page_title = _('Sign in')
-    title = _('Sign in')
+    page_title = _('Log in')
+    title = _('Log in')
 
     def get_context_data(self, **kwargs):
         context = super(self.__class__, self).get_context_data(**kwargs)

--- a/lib/booktype/apps/core/templates/core/nav_bar.html
+++ b/lib/booktype/apps/core/templates/core/nav_bar.html
@@ -12,10 +12,10 @@
 	             <li><a href="{% url "control_center:frontpage" %}" {% if cc_frontpage_url not in request.path %} target="_blank" {% endif %}><i class="icon-gears"></i>{% trans "Control Center" %}</a></li>
 	          {% endif %}
 	          <li class="divider"></li>
-	          <li><a href="{% url "accounts:signout" %}"><i class="icon-signout"></i>{% trans "Logout" %}</a></li>
+	          <li><a href="{% url "accounts:signout" %}"><i class="icon-signout"></i>{% trans "Log out" %}</a></li>
 	        </ul>
 	    {% else %}
-          <button class="btn btn-inverse dropdown-toggle" data-toggle="dropdown" data-href="{% url "accounts:signin" %}?redirect={{ request.path }}">{%  trans "Sign In" %}<span class="caret"></span></button>
+          <button class="btn btn-inverse dropdown-toggle" data-toggle="dropdown" data-href="{% url "accounts:signin" %}?redirect={{ request.path }}">{%  trans "Log in" %}<span class="caret"></span></button>
         {% endif %}
     </div>
 

--- a/lib/booktype/apps/edit/templates/edit/toolbar_user.html
+++ b/lib/booktype/apps/edit/templates/edit/toolbar_user.html
@@ -8,8 +8,8 @@
              <li><a href="{% url "control_center:frontpage" %}" target="_blank"><i class="icon-gears"></i>{% trans "Control Center" %}</a></li>
           {% endif %}
           <li class="divider"></li>
-          <li><a href="{% url "accounts:signout" %}"><i class="icon-signout"></i>{% trans "Logout" %}</a></li>
+          <li><a href="{% url "accounts:signout" %}"><i class="icon-signout"></i>{% trans "Log out" %}</a></li>
         </ul>
     {% else %}
-  <button class="btn btn-inverse dropdown-toggle" data-toggle="dropdown">{%  trans "Sign In" %}<span class="caret"></span></button>
+  <button class="btn btn-inverse dropdown-toggle" data-toggle="dropdown">{%  trans "Log in" %}<span class="caret"></span></button>
 {% endif %}

--- a/lib/booktype/locale/en/LC_MESSAGES/django.po
+++ b/lib/booktype/locale/en/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Booktype 2.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-11-12 13:00+0000\n"
+"POT-Creation-Date: 2015-11-23 16:54+0000\n"
 "PO-Revision-Date: 2015-05-15 11:52+0100\n"
 "Last-Translator: Daniel James <daniel.james@sourcefabric.org>\n"
 "Language-Team: Sourcefabric Localization <contact@sourcefabric.org>\n"
@@ -176,7 +176,9 @@ msgstr ""
 
 #: apps/account/views.py:442 apps/account/views.py:443
 #: apps/account/templates/account/form_signin.html:3
-msgid "Sign in"
+#: apps/core/templates/core/nav_bar.html:18
+#: apps/edit/templates/edit/toolbar_user.html:14
+msgid "Log in"
 msgstr ""
 
 #: apps/account/templates/account/dashboard.html:35
@@ -313,6 +315,8 @@ msgid "Click this button to log out of your Booktype account"
 msgstr ""
 
 #: apps/account/templates/account/dashboard.html:148
+#: apps/core/templates/core/nav_bar.html:15
+#: apps/edit/templates/edit/toolbar_user.html:11
 msgid "Log out"
 msgstr ""
 
@@ -910,16 +914,6 @@ msgstr ""
 #: apps/core/templates/core/nav_bar.html:12
 #: apps/edit/templates/edit/toolbar_user.html:8
 msgid "Control Center"
-msgstr ""
-
-#: apps/core/templates/core/nav_bar.html:15
-#: apps/edit/templates/edit/toolbar_user.html:11
-msgid "Logout"
-msgstr ""
-
-#: apps/core/templates/core/nav_bar.html:18
-#: apps/edit/templates/edit/toolbar_user.html:14
-msgid "Sign In"
 msgstr ""
 
 #: apps/core/templates/core/nav_bar.html:42


### PR DESCRIPTION
Currently we use the strings Sign In, Sign in, Logout and Log out. This commit makes them just 'Log in' and 'Log out' so there will be more consistency and less work for translators.