### PR TITLE
BK-1804 Fix remaining inconsistencies with 'sign in'

### DIFF
--- a/lib/booktype/apps/account/templates/account/form_signin.html
+++ b/lib/booktype/apps/account/templates/account/form_signin.html
@@ -17,6 +17,6 @@
     <div class="unknown-error template">{% trans "Unknown error!" %}</div>
   </div>
 
- <input class="navigation_button btn btn-success" id="next" value="{% trans "Log In" %}" type="submit" /> 
+ <input class="navigation_button btn btn-success" id="next" value="{% trans "Log in" %}" type="submit" /> 
 <a class="float-right" href="{% url 'accounts:forgotpassword' %}">{% trans "Forgotten your password?" %}</a> 
 </form>  

--- a/lib/booktype/apps/account/templates/account/register.html
+++ b/lib/booktype/apps/account/templates/account/register.html
@@ -12,7 +12,7 @@
 <div class="container">
   <div class = "row three-col">
     {% if request.user.is_authenticated %}
-      <h3>{% trans "You are already signed in!" %}</h3>
+      <h3>{% trans "You are already logged in!" %}</h3>
     {% else %}
       <div class="col-xs-4">
           <div class="login-widget box gray">

--- a/lib/booktype/locale/en/LC_MESSAGES/django.po
+++ b/lib/booktype/locale/en/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Booktype 2.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-11-23 16:54+0000\n"
+"POT-Creation-Date: 2015-11-24 09:38+0000\n"
 "PO-Revision-Date: 2015-05-15 11:52+0100\n"
 "Last-Translator: Daniel James <daniel.james@sourcefabric.org>\n"
 "Language-Team: Sourcefabric Localization <contact@sourcefabric.org>\n"
@@ -176,6 +176,7 @@ msgstr ""
 
 #: apps/account/views.py:442 apps/account/views.py:443
 #: apps/account/templates/account/form_signin.html:3
+#: apps/account/templates/account/form_signin.html:20
 #: apps/core/templates/core/nav_bar.html:18
 #: apps/edit/templates/edit/toolbar_user.html:14
 msgid "Log in"
@@ -666,10 +667,6 @@ msgstr ""
 msgid "Unknown error!"
 msgstr ""
 
-#: apps/account/templates/account/form_signin.html:20
-msgid "SIGN IN"
-msgstr ""
-
 #: apps/account/templates/account/form_signin.html:21
 msgid "Forgotten your password?"
 msgstr ""
@@ -692,7 +689,7 @@ msgid ""
 msgstr ""
 
 #: apps/account/templates/account/register.html:15
-msgid "You are already signed in!"
+msgid "You are already logged in!"
 msgstr ""
 
 #: apps/account/templates/account/register.html:29


### PR DESCRIPTION
To avoid duplicate translations, we can use the same string throughout and apply a text-transform where required.