### PR TITLE
BK-1837 Translate Norwegian label in interface language menu

### DIFF
--- a/lib/booktype/skeleton/base_settings.py.original
+++ b/lib/booktype/skeleton/base_settings.py.original
@@ -147,7 +147,7 @@ LANGUAGES = (
    ('it', gettext('Italiano')),
    ('hu', gettext('Magyar')),
    ('nl', gettext('Nederlands')),
-   ('no', gettext('Norwegian')),
+   ('no', gettext('Norsk')),
    ('pl', gettext('Polski')),
    ('pt', gettext('Português')),
    ('ru', gettext('Русский')),


### PR DESCRIPTION
Just because the other labels are shown in the native language.