### PR TITLE
BTPRO-804 Clarify that the Track Changes control is not persistent

### DIFF
--- a/lib/booktype/apps/edit/templates/edit/book_edit.html
+++ b/lib/booktype/apps/edit/templates/edit/book_edit.html
@@ -151,7 +151,7 @@
           {% if track_changes_enable %}
             <div class="row">
                 <div class="col-md-9">
-                    <h4>{% trans "Track changes" %}</h4>
+                    <h4>{% trans "Track changes for this revision only" %}</h4>
                 </div>
             </div>
             <div class="row">

--- a/lib/booktype/locale/en/LC_MESSAGES/django.po
+++ b/lib/booktype/locale/en/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Booktype 2.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-11-24 09:38+0000\n"
+"POT-Creation-Date: 2015-12-21 12:58+0000\n"
 "PO-Revision-Date: 2015-05-15 11:52+0100\n"
 "Last-Translator: Daniel James <daniel.james@sourcefabric.org>\n"
 "Language-Team: Sourcefabric Localization <contact@sourcefabric.org>\n"
@@ -1178,7 +1178,7 @@ msgstr ""
 msgid "Book with right to left writing."
 msgstr ""
 
-#: apps/edit/forms.py:102 apps/edit/templates/edit/book_edit.html:154
+#: apps/edit/forms.py:102
 msgid "Track changes"
 msgstr ""
 
@@ -1677,6 +1677,10 @@ msgstr ""
 #: apps/edit/templates/edit/book_edit.html:149
 #: apps/edit/templates/edit/edit_strings.html:30
 msgid "Tracking Options"
+msgstr ""
+
+#: apps/edit/templates/edit/book_edit.html:154
+msgid "Track changes for this revision only"
 msgstr ""
 
 #: apps/edit/templates/edit/book_edit.html:161


### PR DESCRIPTION
Although the editor sidebar control has the same label as the book-level setting, it has a different effect.