### PR TITLE
BK-1852 Hide heading if users don't have permission to see Security menu

### DIFF
--- a/lib/booktype/apps/edit/templates/edit/panel_settings.html
+++ b/lib/booktype/apps/edit/templates/edit/panel_settings.html
@@ -39,7 +39,10 @@
                     <br>
                     {% endcheck_perm %}
 
+                    {% check_perm 'core.manage_roles' or 'core.manage_permissions' %}
                     <h4>{% trans "Security" %}</h4>
+                    {% endcheck_perm %}
+
                     {% check_perm 'core.manage_roles' %}
                     <li><a href="#roles" data-toggle="tab">{% trans "Roles" %}</a></li>
                     {% endcheck_perm %}


### PR DESCRIPTION
This check should hide the menu heading if users can't see either of the following Security menu items.