### PR TITLE
BK-1805 Createuser command throws an error even when successful

### DIFF
--- a/lib/booktype/apps/core/management/commands/createuser.py
+++ b/lib/booktype/apps/core/management/commands/createuser.py
@@ -16,9 +16,10 @@
 
 from django.core.management.base import BaseCommand, CommandError
 from optparse import make_option
-from django.contrib.auth.models import User
+from django.db.utils import Error
 
 from django.contrib.auth.models import User
+
 
 class Command(BaseCommand):
     help = "Used to create a user"
@@ -57,14 +58,12 @@ class Command(BaseCommand):
                 user = User.objects.create_superuser(username, email, password)
             else:
                 user = User.objects.create_user(username, email, password)
-        
+
             user.first_name = fullname
             user.save()
+            self.stdout.write("\tUser name: {0} email: {1} was successfully created!".format(username, email))
 
-            from booktype.apps.account.models import UserProfile
-            user_profile = UserProfile(user = user)
-            user_profile.save()
-        except:
-            raise CommandError("Could not create the user.")
+        except Error as e:
+            raise CommandError("Could not create the user. {0}".format(e.message))
 
 


### PR DESCRIPTION
The error was due to the code in apps/account/models.py where new user was already bonded with UserProfile class.
So the code in createuser.py (command) was throwing an error, since it was created in models.
Also added the meaningful response, that shows the exact text of the error that's happened, while creating a new user.
Also added a success message.