### PR TITLE
BK-1862 Make Security module more extendable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 setup.cfg
 .env
 .idea
+
+tests/static/css

--- a/lib/booktype/apps/export/utils.py
+++ b/lib/booktype/apps/export/utils.py
@@ -19,7 +19,6 @@ import os
 import json
 import logging
 import urlparse
-import importlib
 
 from lxml import etree
 from collections import OrderedDict
@@ -31,7 +30,7 @@ from ebooklib.utils import parse_html_string
 from booki.editor import models
 from booktype.utils import config
 from booktype.apps.export.models import ExportSettings
-from booktype.utils.misc import TidyPlugin
+from booktype.utils.misc import TidyPlugin, import_from_string
 from booktype.utils.plugins.icejs import IceCleanPlugin
 
 from .epub import ExportEpubBook
@@ -184,7 +183,7 @@ class ExportBook(object):
        (BOOKTYPE_EXPORT_CLASS_MODULE = 'appname.module')
     """
 
-    ATTRIBUTES_GLOBAL =  standard.ATTRIBUTES_GLOBAL + ['data-column', 'data-gap', 'data-valign', 'data-id']
+    ATTRIBUTES_GLOBAL = standard.ATTRIBUTES_GLOBAL + ['data-column', 'data-gap', 'data-valign', 'data-id']
     DEFAULT_PLUGINS = [TidyPlugin(), standard.SyntaxPlugin()]
     PREFIXES = {
         'bkterms': 'http://booktype.org/',
@@ -207,7 +206,6 @@ class ExportBook(object):
         self.hold_chapters_urls = None
         self.embeded_images = {}
         self.atachments = models.Attachment.objects.filter(version=book_version)
-
 
         # ICEjs changes are removed by default, so to keep them in the epub
         # we need to pass remove_icejs as False in kwargs
@@ -432,5 +430,5 @@ class ExportBook(object):
 
 
 def get_exporter_class():
-    module = importlib.import_module(config.get_configuration("BOOKTYPE_EXPORT_CLASS_MODULE"))
-    return getattr(module, 'ExportBook')
+    class_path = "{}.ExportBook".format(config.get_configuration('BOOKTYPE_EXPORT_CLASS_MODULE'))
+    return import_from_string(class_path)

--- a/lib/booktype/constants.py
+++ b/lib/booktype/constants.py
@@ -57,24 +57,28 @@ GOOGLE_ANALYTICS_ID = ''
 MAX_ADDITIONAL_METADATA = 3
 
 BOOKTYPE_THEME_PLUGINS = {
-  'custom': 'booktype.apps.themes.convert.custom',
-  'academic': 'booktype.apps.themes.convert.academic'
+    'custom': 'booktype.apps.themes.convert.custom',
+    'academic': 'booktype.apps.themes.convert.academic'
 }
 
 # define path to module where class ExportBook is located
-BOOKTYPE_EXPORT_CLASS_MODULE = "booktype.apps.export.utils"
+BOOKTYPE_EXPORT_CLASS_MODULE = 'booktype.apps.export.utils'
+
+BOOKTYPE_BASE_SECURITY_CLASS = 'booktype.utils.security.base.BaseSecurity'
 
 EXPORT_WAIT_FOR = 90
 
 EXPORT_SETTINGS = {
-    'mpdf': [{u'name': u'size', u'value': u'A4'}, {u'name': u'custom_width', u'value': u''},
+    'mpdf': [
+        {u'name': u'size', u'value': u'A4'}, {u'name': u'custom_width', u'value': u''},
         {u'name': u'custom_height', u'value': u''}, {u'name': u'top_margin', u'value': u'20'},
         {u'name': u'side_margin', u'value': u'20'}, {u'name': u'bottom_margin', u'value': u'20'},
         {u'name': u'gutter', u'value': u'20'}, {u'name': u'show_header', u'value': u'on'},
         {u'name': u'header_margin', u'value': u'10'}, {u'name': u'show_footer', u'value': u'on'},
         {u'name': u'footer_margin', u'value': u'10'}, {u'name': u'bleed_size', u'value': u''},
         {u'name': u'styling', u'value': u''}, {u'name': u'crop_marks', u'value': u'off'}],
-    'screenpdf': [{u'name': u'size', u'value': u'A4'}, {u'name': u'custom_width', u'value': u''},
+    'screenpdf': [
+        {u'name': u'size', u'value': u'A4'}, {u'name': u'custom_width', u'value': u''},
         {u'name': u'custom_height', u'value': u''}, {u'name': u'top_margin', u'value': u'20'},
         {u'name': u'side_margin', u'value': u'20'}, {u'name': u'bottom_margin', u'value': u'20'},
         {u'name': u'gutter', u'value': u'20'}, {u'name': u'show_header', u'value': u'on'},

--- a/lib/booktype/utils/security/__init__.py
+++ b/lib/booktype/utils/security/__init__.py
@@ -2,9 +2,13 @@
 import logging
 from booktype.utils import config
 from booki.editor.models import BookiPermission
-from booktype.apps.core.models import Permission, Role
+from booktype.apps.core.models import Permission
+
+from ..misc import import_from_string
+from .base import get_default_role, get_default_role_key
 
 logger = logging.getLogger('booktype.utils.security')
+Security = import_from_string(config.get_configuration('BOOKTYPE_BASE_SECURITY_CLASS'))
 
 
 def has_perm(user, to_do, book=None):
@@ -79,165 +83,6 @@ def get_user_permissions(user, book):
             ]
 
     return permissions
-
-
-def get_default_role_key(user):
-    """
-    Returns the defaults booktype app role key for given user
-    even if is not registered
-    """
-    if user.is_authenticated():
-        role_key = 'registered_users'
-    else:
-        role_key = 'anonymous_users'
-
-    return role_key
-
-
-def get_default_role(key, book=None):
-    """
-    Returns default role if exists one already registered
-    in system database, otherwise returns None
-    """
-
-    default_role = None
-    default_key = 'DEFAULT_ROLE_%s' % key
-    role_name = None
-
-    if book:
-        try:
-            role_name = book.settings.get(name=default_key).get_value()
-        except:
-            logger.info("There is no Role name for role_key %s" % default_key)
-
-    if not role_name:
-        role_name = config.get_configuration(
-            default_key, key)
-
-    # no_role means restricted
-    if role_name == '__no_role__':
-        return None
-
-    try:
-        default_role = Role.objects.get(name=role_name)
-    except:
-        logger.info("Role with %s name does not exists" % role_name)
-
-    return default_role
-
-
-class Security(object):
-    """Base security object for doing security checks.
-
-    User is supposed to inherit this object and use it for custom security checks.
-    """
-
-    def __init__(self, user):
-        """Initialize base security object.
-
-        :Args:
-         - user (:class:`django.contrib.auth.models.User`) - User object
-        """
-        self.user = user
-        self.permissions = []
-
-    def is_superuser(self):
-        """Checks if user is Django superuser or not.
-
-        :Returns:
-         - Returns True if user is superuser.
-        """
-        return self.user.is_superuser
-
-    def is_staff(self):
-        """Checks if user is Django staff member or not.
-
-        :Returns:
-         - Returns True if user is staff member.
-        """
-        return self.user.is_staff
-
-    def is_admin(self):
-        """Checks is user is any kind of admin.
-
-        :Returns:
-         - Returns True if user is superuser.
-        """
-        return self.is_superuser()
-
-    @staticmethod
-    def get_permission_from_string(permission_string):
-        """Retrieving permission instance based on permission string
-
-        :Args:
-          - permission_string (:class:`str`): Concatenated string of app name and permission codename
-                                              e.g. "editor.create_chapter"
-
-        :Returns:
-          Returns (:class:`booktype.apps.core.models.Permission`) instance or None
-
-        :Raises:
-          Exception: If wrong permission string was provided
-        """
-        try:
-            app_name, codename = permission_string.split('.')
-            return Permission.objects.get(app_name=app_name, name=codename)
-        except ValueError:
-            raise Exception("permission_string parameter should be 'app_name.permission' way")
-        except Permission.DoesNotExist:
-            return None
-
-    def _get_permissions(self, book=None):
-        """Retrieving permissions set
-
-        :Args:
-          - book (:class:`booki.editor.models.Book`): Book instance. Optional.
-
-        :Returns:
-          Returns (:class:`set`) Set of permissions
-        """
-        permissions = set()
-        # get default role key for extra permissions
-        role_key = get_default_role_key(self.user)
-        default_role = get_default_role(role_key, book)
-
-        # append permissions from default role, no matter if book or not
-        if default_role:
-            permissions.update([p for p in default_role.permissions.all()])
-
-        if self.user.is_authenticated():
-            if book:
-                bookroles = self.user.roles.filter(book=book)
-                for bookrole in bookroles:
-                    permissions.update([p for p in bookrole.role.permissions.all()])
-        return permissions
-
-    def has_perm(self, perm):
-        """
-        Checks if a given user has rights to execute an specific
-        task or action.
-
-        Args:
-            perm: Concatenated string of app name and permission codename
-                e.g. "editor.create_chapter"
-
-        Returns:
-            Boolean
-        """
-
-        if self.is_admin():
-            return True
-
-        # convert concatenated app name and permission codename string to permission instance
-        permission = self.get_permission_from_string(perm)
-        if not permission:
-            return False
-
-        # query permissions only once
-        if not self.permissions:
-            self.permissions = self._get_permissions()
-
-        return permission in self.permissions
 
 
 class BookSecurity(Security):

--- a/lib/booktype/utils/security/base.py
+++ b/lib/booktype/utils/security/base.py
@@ -1,0 +1,171 @@
+# -*- coding: utf-8 -*-
+import logging
+
+from booktype.utils import config
+from booktype.apps.core.models import Permission, Role
+
+logger = logging.getLogger('booktype.utils.security.base')
+
+
+class BaseSecurity(object):
+    """Base security object for doing security checks.
+
+    User is supposed to inherit this object and use it for custom security checks.
+    """
+
+    def __init__(self, user):
+        """Initialize base security object.
+
+        :Args:
+         - user (:class:`django.contrib.auth.models.User`) - User object
+        """
+        self.user = user
+        self.permissions = []
+
+    def is_superuser(self):
+        """Checks if user is Django superuser or not.
+
+        :Returns:
+         - Returns True if user is superuser.
+        """
+        return self.user.is_superuser
+
+    def is_staff(self):
+        """Checks if user is Django staff member or not.
+
+        :Returns:
+         - Returns True if user is staff member.
+        """
+        return self.user.is_staff
+
+    def is_admin(self):
+        """Checks is user is any kind of admin.
+
+        :Returns:
+         - Returns True if user is superuser.
+        """
+        return self.is_superuser()
+
+    @staticmethod
+    def get_permission_from_string(permission_string):
+        """Retrieving permission instance based on permission string
+
+        :Args:
+          - permission_string (:class:`str`): Concatenated string of app name and permission codename
+                                              e.g. "editor.create_chapter"
+
+        :Returns:
+          Returns (:class:`booktype.apps.core.models.Permission`) instance or None
+
+        :Raises:
+          Exception: If wrong permission string was provided
+        """
+        try:
+            app_name, codename = permission_string.split('.')
+            return Permission.objects.get(app_name=app_name, name=codename)
+        except ValueError:
+            raise Exception("permission_string parameter should be 'app_name.permission' way")
+        except Permission.DoesNotExist:
+            return None
+
+    def _get_default_role(self, book=None):
+        """
+        Returns the default role to get extra permissions
+        """
+        role_key = get_default_role_key(self.user)
+        return get_default_role(role_key, book)
+
+    def _get_permissions(self, book=None):
+        """Retrieving permissions set
+
+        :Args:
+          - book (:class:`booki.editor.models.Book`): Book instance. Optional.
+
+        :Returns:
+          Returns (:class:`set`) Set of permissions
+        """
+        permissions = set()
+        default_role = self._get_default_role(book)
+
+        # append permissions from default role, no matter if book or not
+        if default_role:
+            permissions.update([p for p in default_role.permissions.all()])
+
+        if self.user.is_authenticated():
+            if book:
+                bookroles = self.user.roles.filter(book=book)
+                for bookrole in bookroles:
+                    permissions.update([p for p in bookrole.role.permissions.all()])
+        return permissions
+
+    def has_perm(self, perm):
+        """
+        Checks if a given user has rights to execute an specific
+        task or action.
+
+        Args:
+            perm: Concatenated string of app name and permission codename
+                e.g. "editor.create_chapter"
+
+        Returns:
+            Boolean
+        """
+
+        if self.is_admin():
+            return True
+
+        # convert concatenated app name and permission codename string to permission instance
+        permission = self.get_permission_from_string(perm)
+        if not permission:
+            return False
+
+        # query permissions only once
+        if not self.permissions:
+            self.permissions = self._get_permissions()
+
+        return permission in self.permissions
+
+
+def get_default_role_key(user):
+    """
+    Returns the defaults booktype app role key for given user
+    even if is not registered
+    """
+    if user.is_authenticated():
+        role_key = 'registered_users'
+    else:
+        role_key = 'anonymous_users'
+
+    return role_key
+
+
+def get_default_role(key, book=None):
+    """
+    Returns default role if exists one already registered
+    in system database, otherwise returns None
+    """
+
+    default_role = None
+    default_key = 'DEFAULT_ROLE_%s' % key
+    role_name = None
+
+    if book:
+        try:
+            role_name = book.settings.get(name=default_key).get_value()
+        except:
+            logger.info("There is no Role name for role_key %s" % default_key)
+
+    if not role_name:
+        role_name = config.get_configuration(
+            default_key, key)
+
+    # no_role means restricted
+    if role_name == '__no_role__':
+        return None
+
+    try:
+        default_role = Role.objects.get(name=role_name)
+    except:
+        logger.info("Role with %s name does not exists" % role_name)
+
+    return default_role

--- a/lib/booktype/utils/tests/test_security.py
+++ b/lib/booktype/utils/tests/test_security.py
@@ -112,7 +112,7 @@ class SecurityUtilsTestCase(TestCase):
 
     def test_get_security(self):
         # let's test helper for retrieving base Security instance
-        self.assertEqual(security.Security(self.user).__class__,
+        self.assertEqual(security.base.BaseSecurity(self.user).__class__,
                          security.get_security(self.user).__class__)
 
     def test_get_security_for_book(self):
@@ -189,20 +189,20 @@ class SecurityClassTestCase(TestCase):
 
     def test_get_permission_from_string(self):
         # get permission by name
-        permission = security.Security.get_permission_from_string("{app}.{name}".format(app=APP_NAME,
-                                                                                        name=CODE_NAME))
+        permission = security.base.BaseSecurity.get_permission_from_string(
+            "{app}.{name}".format(app=APP_NAME, name=CODE_NAME))
         self.assertEqual(permission, self.can_test_permission)
 
         # try to get permission with wrong argument
         self.assertRaises(Exception,
-                          security.Security.get_permission_from_string, "can_do_everything")
+                          security.base.BaseSecurity.get_permission_from_string, "can_do_everything")
 
         # try to get net existing permission
-        self.assertFalse(security.Security.get_permission_from_string("fake.permission"))
+        self.assertFalse(security.base.BaseSecurity.get_permission_from_string("fake.permission"))
 
     def test_get_permissions_success(self):
         # mock get_default_role function
-        security.get_default_role = mock.Mock(return_value=self.role_registered_user)
+        security.base.get_default_role = mock.Mock(return_value=self.role_registered_user)
 
         sec = security.get_security(self.user)
         self.assertIn(self.can_content_register_permission, sec._get_permissions())
@@ -212,7 +212,7 @@ class SecurityClassTestCase(TestCase):
 
     def test_get_permissions_fail(self):
         # mock get_default_role function
-        security.get_default_role = mock.Mock(return_value=self.role)
+        security.base.get_default_role = mock.Mock(return_value=self.role)
 
         sec = security.get_security(self.superuser)
         self.assertNotIn(self.can_content_register_permission, sec._get_permissions())
@@ -221,7 +221,7 @@ class SecurityClassTestCase(TestCase):
         # get permissions from default role and from bookrole
 
         # mock get_default_role function
-        security.get_default_role = mock.Mock(return_value=self.role_registered_user)
+        security.base.get_default_role = mock.Mock(return_value=self.role_registered_user)
 
         sec = security.get_security(self.user)
         permissions = sec._get_permissions(book=self.bookrole.book)
@@ -248,7 +248,7 @@ class SecurityClassTestCase(TestCase):
 
         # common user, should have rights
         # mock get_default_role function
-        security.get_default_role = mock.Mock(return_value=self.role_registered_user)
+        security.base.get_default_role = mock.Mock(return_value=self.role_registered_user)
         self.assertTrue(sec.has_perm("content.register"),
                         "If user doesn't have that role, this should be False")
 


### PR DESCRIPTION
This PRs allow us to extends the Security module in custom instances, doing something like this:

```python
# in settings file 
BOOKTYPE_BASE_SECURITY_CLASS = 'my_book_site.custom.module.Security'
```

```python
# in the Security module
from booktype.utils.security.base import BaseSecurity

class MySecurity(BaseSecurity):
    """ own security class """

    def _get_default_role(self, book=None):
        if user.is_something:
            return CustomDefaultRole() # with custom permissions
        
        return super(MySecurity, self)._get_default_role(book)
```

then BookSecurity and GroupSecurity will inherit this class and this will be the standard Security object used inside Booktype

