### PR TITLE
BK-1385 Make page break method simpler

### DIFF
--- a/lib/booktype/apps/themes/templates/themes/academic/body_mpdf.html
+++ b/lib/booktype/apps/themes/templates/themes/academic/body_mpdf.html
@@ -22,28 +22,28 @@
 
 <tocpagebreak links="on" pagenumstyle="1" toc-suppress="1" toc-resetpagenum="1"></tocpagebreak>
 
-{% assign was_chapter 0 %}
-
 {% for item in book_items %}
   {% if item.type == 'chapter' %}
-    {% if was_chapter %}
-      {# <pagebreak />  #}
-    {% endif %}
-
     {% if not forloop.first %}
-    <div class="chapter"></div>
+    <pagebreak />
     {% endif %}
+    <sethtmlpageheader name="header-left" page="even" value="on" show-this-page="on" />
+    <sethtmlpageheader name="header-right" page="odd" value="on" show-this-page="on" />
+    <sethtmlpagefooter name="footer-left" page="even" value="on" />
+    <sethtmlpagefooter name="footer-right" page="odd" value="on" />
     <tocentry level="1" content="{{ item.title }}"></tocentry>
     {{ item.content|safe }}
-    {% assign was_chapter 1 %}
   {% endif %}
 
   {% if item.type == 'section' %}
     {% if not forloop.first %}
-    <div class="section"></div>
+    <pagebreak type="next-odd" />
     {% endif %}
+    <sethtmlpageheader page="odd" value="off" />
+    <sethtmlpageheader page="even" value="off" />
+    <sethtmlpagefooter page="odd" value="off" />
+    <sethtmlpagefooter page="even" value="off" />
     <tocentry level="0" content="{{ item.title }}"></tocentry>
     <h1 class="section">{{ item.title }}</h1>
-    {% assign was_chapter 0 %}
   {% endif %}
 {% endfor %}

--- a/lib/booktype/apps/themes/templates/themes/academic/body_screenpdf.html
+++ b/lib/booktype/apps/themes/templates/themes/academic/body_screenpdf.html
@@ -22,28 +22,28 @@
 
 <tocpagebreak links="on" pagenumstyle="1" toc-suppress="1" toc-resetpagenum="1"></tocpagebreak>
 
-{% assign was_chapter 0 %}
-
 {% for item in book_items %}
   {% if item.type == 'chapter' %}
-    {% if was_chapter %}
-      {# <pagebreak />  #}
-    {% endif %}
-
     {% if not forloop.first %}
-    <div class="chapter"></div>
+    <pagebreak />
     {% endif %}
+    <sethtmlpageheader name="header-left" page="even" value="on" show-this-page="on" />
+    <sethtmlpageheader name="header-right" page="odd" value="on" show-this-page="on" />
+    <sethtmlpagefooter name="footer-left" page="even" value="on" />
+    <sethtmlpagefooter name="footer-right" page="odd" value="on" />
     <tocentry level="1" content="{{ item.title }}"></tocentry>
     {{ item.content|safe }}
-    {% assign was_chapter 1 %}
   {% endif %}
 
   {% if item.type == 'section' %}
     {% if not forloop.first %}
-    <div class="section"></div>
+    <pagebreak />
     {% endif %}
+    <sethtmlpageheader page="odd" value="off" />
+    <sethtmlpageheader page="even" value="off" />
+    <sethtmlpagefooter page="odd" value="off" />
+    <sethtmlpagefooter page="even" value="off" />
     <tocentry level="0" content="{{ item.title }}"></tocentry>
     <h1 class="section">{{ item.title }}</h1>
-    {% assign was_chapter 0 %}
   {% endif %}
 {% endfor %}

--- a/lib/booktype/apps/themes/templates/themes/academic/endmatter_mpdf.html
+++ b/lib/booktype/apps/themes/templates/themes/academic/endmatter_mpdf.html
@@ -1,2 +1,0 @@
-<!-- Insert a pagebreak in case there is an index at the end -->
-    <pagebreak />

--- a/lib/booktype/apps/themes/templates/themes/academic/endmatter_screenpdf.html
+++ b/lib/booktype/apps/themes/templates/themes/academic/endmatter_screenpdf.html
@@ -1,2 +1,0 @@
-<!-- Insert a pagebreak in case there is an index at the end -->
-    <pagebreak />

--- a/lib/booktype/apps/themes/templates/themes/academic/frontmatter_mpdf.html
+++ b/lib/booktype/apps/themes/templates/themes/academic/frontmatter_mpdf.html
@@ -228,7 +228,7 @@
 {% endif %}
 
 <p class="impl">This book was created with Booktype.<br/>
-For more information, please visit: <a href="https://www.booktype.pro/">www.booktype.pro</a></p>
+For more information, please visit: www.booktype.pro</p>
 
 <!-- END IMPRESSUM -->
 

--- a/lib/booktype/apps/themes/templates/themes/academic/frontmatter_screenpdf.html
+++ b/lib/booktype/apps/themes/templates/themes/academic/frontmatter_screenpdf.html
@@ -42,11 +42,11 @@
 <!-- IF WE HAVE COVER, INSERT A DIV FOR IT -->
 {% if cover_image != '' %}
 <div class="frontcover"></div>
-{% endif %}
 
-<!-- START FRONTMATTER -->
+<!-- EMPTY PAGE -->
 <div class="frontmatter"></div>
 <pagebreak />
+{% endif %}
 
 <!-- START HALF TITLE -->
 <div class="frontmatter-half-title">{{ title }}</div>

--- a/lib/booktype/apps/themes/templates/themes/style_mpdf.css
+++ b/lib/booktype/apps/themes/templates/themes/style_mpdf.css
@@ -9,42 +9,13 @@
 
   {% if show_footer %}
   margin-footer: {{ footer_margin }}mm;
-
-  odd-footer-name: html_footer-right;
-  even-footer-name: html_footer-left;
   {% endif %}
 
   {% if show_header %}
   margin-header: {{ header_margin }}mm;
-
-  odd-header-name: html_header-right;
-  even-header-name: html_header-left;
   {% endif %}
       
   {% if crop_marks %}
   marks: crop cross;    
   {% endif %}        
 }
-
-@page section {
-  odd-header-name: _blank;
-  even-header-name: _blank;        
-}
-
-@page chapter {
-  {% if show_header %}
-  margin-header: {{ header_margin }}mm;
-
-  odd-header-name: html_header-right;
-  even-header-name: html_header-left;
-  {% endif %}
-}
-
-div.section {
-  page: section;
-}
-
-div.chapter {
-  page: chapter;
-}
-

--- a/lib/booktype/apps/themes/templates/themes/style_screenpdf.css
+++ b/lib/booktype/apps/themes/templates/themes/style_screenpdf.css
@@ -9,16 +9,10 @@
 
   {% if show_footer %}
   margin-footer: {{ footer_margin }}mm;
-
-  odd-footer-name: html_footer-right;
-  even-footer-name: html_footer-left;
   {% endif %}
 
   {% if show_header %}
   margin-header: {{ header_margin }}mm;
-      
-  odd-header-name: html_header-right;
-  even-header-name: html_header-left;
   {% endif %}
 }
 
@@ -26,28 +20,11 @@
 @page frontcover {
   background-image: url('{{ cover_image }}');
   background-image-resize: 6;
-  footer: none;
-  header: none;
 }
 {% endif %}
 
 @page frontmatter {
-  odd-header-name: _blank;
-  even-header-name: _blank;
-}
-
-@page section {
-  odd-header-name: _blank;
-  even-header-name: _blank;        
-}
-
-@page chapter {
-  {% if show_header %}
-  margin-header: {{ header_margin }}mm;
-
-  odd-header-name: html_header-right;
-  even-header-name: html_header-left;
-  {% endif %}
+  background-image: none;
 }
 
 div.frontcover {
@@ -56,12 +33,4 @@ div.frontcover {
 
 div.frontmatter {
   page: frontmatter;
-}
-
-div.section {
-  page: section;
-}
-
-div.chapter {
-  page: chapter;
 }


### PR DESCRIPTION
Using @page and pagebreak tags in combination is not reliable when the order of chapters and sections is arbitrary. So let's not use @page to switch between chapters and sections only to change header and footer visibility.

Please note that sections only start on an odd-numbered page for print PDF, as screen PDF is not left/right sided. This has the bonus of fewer blank pages to scroll through for screen PDF readers. 