### PR TITLE
BK-1907 Set default header and footer names using @page rule

### DIFF
--- a/lib/booktype/apps/themes/templates/themes/academic/body_mpdf.html
+++ b/lib/booktype/apps/themes/templates/themes/academic/body_mpdf.html
@@ -27,10 +27,6 @@
     {% if not forloop.first %}
     <pagebreak />
     {% endif %}
-    <sethtmlpageheader name="header-left" page="even" value="on" show-this-page="on" />
-    <sethtmlpageheader name="header-right" page="odd" value="on" show-this-page="on" />
-    <sethtmlpagefooter name="footer-left" page="even" value="on" />
-    <sethtmlpagefooter name="footer-right" page="odd" value="on" />
     <tocentry level="1" content="{{ item.title }}"></tocentry>
     {{ item.content|safe }}
   {% endif %}
@@ -39,8 +35,6 @@
     {% if not forloop.first %}
     <pagebreak type="next-odd" />
     {% endif %}
-    <sethtmlpageheader page="odd" value="off" />
-    <sethtmlpageheader page="even" value="off" />
     <sethtmlpagefooter page="odd" value="off" />
     <sethtmlpagefooter page="even" value="off" />
     <tocentry level="0" content="{{ item.title }}"></tocentry>

--- a/lib/booktype/apps/themes/templates/themes/academic/body_screenpdf.html
+++ b/lib/booktype/apps/themes/templates/themes/academic/body_screenpdf.html
@@ -27,10 +27,6 @@
     {% if not forloop.first %}
     <pagebreak />
     {% endif %}
-    <sethtmlpageheader name="header-left" page="even" value="on" show-this-page="on" />
-    <sethtmlpageheader name="header-right" page="odd" value="on" show-this-page="on" />
-    <sethtmlpagefooter name="footer-left" page="even" value="on" />
-    <sethtmlpagefooter name="footer-right" page="odd" value="on" />
     <tocentry level="1" content="{{ item.title }}"></tocentry>
     {{ item.content|safe }}
   {% endif %}
@@ -39,8 +35,6 @@
     {% if not forloop.first %}
     <pagebreak />
     {% endif %}
-    <sethtmlpageheader page="odd" value="off" />
-    <sethtmlpageheader page="even" value="off" />
     <sethtmlpagefooter page="odd" value="off" />
     <sethtmlpagefooter page="even" value="off" />
     <tocentry level="0" content="{{ item.title }}"></tocentry>

--- a/lib/booktype/apps/themes/templates/themes/custom/body_mpdf.html
+++ b/lib/booktype/apps/themes/templates/themes/custom/body_mpdf.html
@@ -27,10 +27,6 @@
     {% if not forloop.first %}
     <pagebreak />
     {% endif %}
-    <sethtmlpageheader name="header-left" page="even" value="on" show-this-page="on" />
-    <sethtmlpageheader name="header-right" page="odd" value="on" show-this-page="on" />
-    <sethtmlpagefooter name="footer-left" page="even" value="on" />
-    <sethtmlpagefooter name="footer-right" page="odd" value="on" />
     <tocentry level="1" content="{{ item.title }}"></tocentry>
     {{ item.content|safe }}
   {% endif %}
@@ -39,8 +35,6 @@
     {% if not forloop.first %}
     <pagebreak type="next-odd" />
     {% endif %}
-    <sethtmlpageheader page="odd" value="off" />
-    <sethtmlpageheader page="even" value="off" />
     <sethtmlpagefooter page="odd" value="off" />
     <sethtmlpagefooter page="even" value="off" />
     <tocentry level="0" content="{{ item.title }}"></tocentry>

--- a/lib/booktype/apps/themes/templates/themes/custom/body_screenpdf.html
+++ b/lib/booktype/apps/themes/templates/themes/custom/body_screenpdf.html
@@ -27,10 +27,6 @@
     {% if not forloop.first %}
     <pagebreak />
     {% endif %}
-    <sethtmlpageheader name="header-left" page="even" value="on" show-this-page="on" />
-    <sethtmlpageheader name="header-right" page="odd" value="on" show-this-page="on" />
-    <sethtmlpagefooter name="footer-left" page="even" value="on" />
-    <sethtmlpagefooter name="footer-right" page="odd" value="on" />
     <tocentry level="1" content="{{ item.title }}"></tocentry>
     {{ item.content|safe }}
   {% endif %}
@@ -39,8 +35,6 @@
     {% if not forloop.first %}
     <pagebreak />
     {% endif %}
-    <sethtmlpageheader page="odd" value="off" />
-    <sethtmlpageheader page="even" value="off" />
     <sethtmlpagefooter page="odd" value="off" />
     <sethtmlpagefooter page="even" value="off" />
     <tocentry level="0" content="{{ item.title }}"></tocentry>

--- a/lib/booktype/apps/themes/templates/themes/style_mpdf.css
+++ b/lib/booktype/apps/themes/templates/themes/style_mpdf.css
@@ -9,10 +9,14 @@
 
   {% if show_footer %}
   margin-footer: {{ footer_margin }}mm;
+  odd-footer-name: html_footer-right;
+  even-footer-name: html_footer-left;
   {% endif %}
 
   {% if show_header %}
   margin-header: {{ header_margin }}mm;
+  odd-header-name: html_header-right;
+  even-header-name: html_header-left;
   {% endif %}
       
   {% if crop_marks %}

--- a/lib/booktype/apps/themes/templates/themes/style_screenpdf.css
+++ b/lib/booktype/apps/themes/templates/themes/style_screenpdf.css
@@ -9,10 +9,14 @@
 
   {% if show_footer %}
   margin-footer: {{ footer_margin }}mm;
+  odd-footer-name: html_footer-right;
+  even-footer-name: html_footer-left;
   {% endif %}
 
   {% if show_header %}
   margin-header: {{ header_margin }}mm;
+  odd-header-name: html_header-right;
+  even-header-name: html_header-left;
   {% endif %}
 }
 


### PR DESCRIPTION
We can set default header and footer names if the user has checked the boxes for these options, switching off the footers when required by the theme, for example on section pages.

The effect is that every page in the body of the book will get a page number, unless we explicitly switch it off using sethtmlpagefooter. 

Frontmatter is not affected because the named headers and footers are not yet defined at that point in the output file. Table of Contents pages have their own settings for showing page numbers or not.