### PR TITLE
BK-1385 Table of Contents needs explicit font-family to avoid default

### DIFF
--- a/lib/booktype/skeleton/themes/academic/mpdf.css
+++ b/lib/booktype/skeleton/themes/academic/mpdf.css
@@ -98,6 +98,7 @@ div.frontmatter-line {
 
 div.mpdf_toc {
   font-size: 1rem;
+  font-family: "roboto";
 }
 
 span.mpdf_toc_t_level_0 {

--- a/lib/booktype/skeleton/themes/academic/screenpdf.css
+++ b/lib/booktype/skeleton/themes/academic/screenpdf.css
@@ -98,6 +98,7 @@ div.frontmatter-line {
 
 div.mpdf_toc {
   font-size: 1rem;
+  font-family: "roboto";
 }
 
 span.mpdf_toc_t_level_0 {

--- a/lib/booktype/skeleton/themes/custom/mpdf.css
+++ b/lib/booktype/skeleton/themes/custom/mpdf.css
@@ -107,6 +107,22 @@ div.frontmatter-subtitle {
   font-size: 22pt;
 }
 
+div.mpdf_toc {
+  font-size: 1rem;
+  font-family: "{{ fontP }}";
+}
+
+span.mpdf_toc_t_level_0 {
+  font-weight: bold;
+  text-transform: none;
+}
+
+span.mpdf_toc_t_level_1 {
+  font-weight: normal;
+  font-style: normal;
+  text-transform: none;
+}
+
 td, p, li {
   line-height: {{ lineHeightP }}%;
   font-family: "{{ fontP }}";

--- a/lib/booktype/skeleton/themes/custom/screenpdf.css
+++ b/lib/booktype/skeleton/themes/custom/screenpdf.css
@@ -179,6 +179,22 @@ div.frontmatter-line {
   page-break-after: always;
 }
 
+div.mpdf_toc {
+  font-size: 1rem;
+  font-family: "{{ fontP }}";
+}
+
+span.mpdf_toc_t_level_0 {
+  font-weight: bold;
+  text-transform: none;
+}
+
+span.mpdf_toc_t_level_1 {
+  font-weight: normal;
+  font-style: normal;
+  text-transform: none;
+}
+
 td, p, li {
   line-height: {{ lineHeightP }}%;
   font-family: "{{ fontP }}";


### PR DESCRIPTION
Without this change, you always get DejaVu Sans for the ToC. This can also increase PDF size, as a subset of DejaVu Sans gets embedded along with whatever font you actually wanted.

Also turn off the bold-by-default for all ToC lines, and italic-by-default for chapter lines in the Custom theme. It's kind of heavy.