### PR TITLE
BK-1928 Write extra mPDF configuration in the theme config file

### DIFF
--- a/lib/booktype/convert/mpdf/converter.py
+++ b/lib/booktype/convert/mpdf/converter.py
@@ -39,7 +39,7 @@ from .styles import create_default_style, get_page_size, CROP_MARGIN
 from booktype.apps.convert import plugin
 from booktype.apps.themes.utils import (
     read_theme_style, get_single_frontmatter, get_single_endmatter, get_body,
-    read_theme_assets, read_theme_asset_content)
+    read_theme_assets, read_theme_asset_content, read_theme_info)
 from booktype.apps.convert.templatetags.convert_tags import (
     get_refines, get_metadata)
 from booktype.utils.misc import booktype_slugify
@@ -213,6 +213,9 @@ class MPDFConverter(BaseConverter):
 
         if self.theme_plugin:
             data['mpdf'] = self.theme_plugin.get_mpdf_config()
+
+        # get additional mpdf configuration options
+        data.setdefault('mpdf', {}).update(self._get_theme_mpdf_config())
 
         return data
 
@@ -738,5 +741,20 @@ class MPDFConverter(BaseConverter):
         except Exception as e:
             logger.error(
                 'MPDF Converter::Fail running the command "{}".'.format(e))
+
+        return {}
+
+    def _get_theme_mpdf_config(self):
+        """
+        Checks the theme info.json file and returns the additional options for mpdf
+        if there is any defined inside of it.
+        """
+
+        profile = self.name
+        data = read_theme_info('{}/themes/{}/info.json'.format(settings.BOOKTYPE_ROOT, self.theme_name))
+
+        if 'output' in data:
+            if profile in data['output']:
+                return data['output'][profile].get('options', {})
 
         return {}

--- a/lib/booktype/convert/screenpdf/converter.py
+++ b/lib/booktype/convert/screenpdf/converter.py
@@ -29,14 +29,19 @@ class ScreenPDFConverter(MPDFConverter):
     def __init__(self, *args, **kwargs):
         super(ScreenPDFConverter, self).__init__(*args, **kwargs)
 
-    def get_extra_configuration(self):        
-        return {'mirror_margins': False}
+    def get_extra_configuration(self):
+        data = {'mirror_margins': False}
+
+        # get additional mpdf configuration options
+        data.setdefault('mpdf', {}).update(self._get_theme_mpdf_config())
+
+        return data
 
     def get_extra_style(self, book):
         cover_image = ''
 
         if 'cover_image' in self.config:
-            cover_asset = self.get_asset(self.config['cover_image'])            
+            cover_asset = self.get_asset(self.config['cover_image'])
             cover_image = cover_asset.file_path
 
         return {'cover_image': cover_image}

--- a/lib/booktype/skeleton/themes/academic/info.json
+++ b/lib/booktype/skeleton/themes/academic/info.json
@@ -1,29 +1,30 @@
-{"version": "0.1",
- "name": "Academic",
- "output": {
-   "mpdf": {
-     "frontmatter": "frontmatter_mpdf.html",
-     "endmatter": "endmatter_mpdf.html",
-     "body": "body_mpdf.html"
-   },
-
-   "screenpdf": {
-     "frontmatter": "frontmatter_screenpdf.html",
-     "endmatter": "endmatter_screenpdf.html",
-     "body": "body_screenpdf.html"
-   },
-
-   "epub": {
-     "assets": {
-       "fonts": [
-         "static/fonts/Roboto-Bold.ttf",
-         "static/fonts/Roboto-Italic.ttf",
-         "static/fonts/Roboto-BoldItalic.ttf",
-         "static/fonts/Roboto-Regular.ttf",
-         "static/fonts/Roboto-Medium.ttf",
-         "static/fonts/Roboto-MediumItalic.ttf"
-       ]
-     }
-   }
- }
+{
+  "version": "0.1",
+  "name": "Academic",
+  "output": {
+    "mpdf": {
+      "options": {},
+      "frontmatter": "frontmatter_mpdf.html",
+      "endmatter": "endmatter_mpdf.html",
+      "body": "body_mpdf.html"
+    },
+    "screenpdf": {
+      "options": {},
+      "frontmatter": "frontmatter_screenpdf.html",
+      "endmatter": "endmatter_screenpdf.html",
+      "body": "body_screenpdf.html"
+    },
+    "epub": {
+      "assets": {
+        "fonts": [
+          "static/fonts/Roboto-Bold.ttf",
+          "static/fonts/Roboto-Italic.ttf",
+          "static/fonts/Roboto-BoldItalic.ttf",
+          "static/fonts/Roboto-Regular.ttf",
+          "static/fonts/Roboto-Medium.ttf",
+          "static/fonts/Roboto-MediumItalic.ttf"
+        ]
+      }
+    }
+  }
 }

--- a/scripts/booktype2mpdf.php
+++ b/scripts/booktype2mpdf.php
@@ -4,7 +4,7 @@ error_reporting(0);
 /* Parse the arguments */
 
 $shortopts = "m:d:o:";
-$longopts = array(
+$longopts  = array(
     "mpdf:",
     "dir:",
     "output:",
@@ -14,14 +14,14 @@ $options = getopt($shortopts, $longopts);
 
 chdir($options["dir"]);
 
-$file_input = $options["dir"]."/body.html";
+$file_input  = $options["dir"] . "/body.html";
 $file_output = $options["output"];
 
 /* Include mPDF library */
-include($options["mpdf"]."/mpdf.php");
+include $options["mpdf"] . "/mpdf.php";
 
-if(file_exists($options["dir"]."/config.json")) {
-    $data = file_get_contents($options["dir"]."/config.json");
+if (file_exists($options["dir"] . "/config.json")) {
+    $data   = file_get_contents($options["dir"] . "/config.json");
     $config = json_decode($data, true);
 }
 
@@ -32,30 +32,30 @@ $html = file_get_contents($file_input);
 
 /*
 $mpdf = new mPDF('', array($config["config"]["page_width_bleed"], $config["config"]["page_height_bleed"]), '', '',
-  $config["config"]["settings"]["gutter"], $config["config"]["settings"]["side_margin"],
-  $config["config"]["settings"]["top_margin"], $config["config"]["settings"]["bottom_margin"],
-  $config["config"]["settings"]["header_margin"], $config["config"]["settings"]["footer_margin"]);
-*/
+$config["config"]["settings"]["gutter"], $config["config"]["settings"]["side_margin"],
+$config["config"]["settings"]["top_margin"], $config["config"]["settings"]["bottom_margin"],
+$config["config"]["settings"]["header_margin"], $config["config"]["settings"]["footer_margin"]);
+ */
 
 $mpdf = new mPDF();
 
 // Specify whether to substitute missing characters in UTF-8 (multibyte) documents
-$mpdf->useSubstitutions=false;
+$mpdf->useSubstitutions = false;
 
 //Disables complex table borders etc. to improve performance
 $mpdf->simpleTables = true;
 
-if(array_key_exists('mirror_margins', $config)) {
-  if($config['mirror_margins']) {
-    // Make it DOUBLE SIDED document
-    $mpdf->mirrorMargins = 1;
-  }
+if (array_key_exists('mirror_margins', $config)) {
+    if ($config['mirror_margins']) {
+        // Make it DOUBLE SIDED document
+        $mpdf->mirrorMargins = 1;
+    }
 }
 
-if(array_key_exists('mpdf', $config)) {
-  foreach($config['mpdf'] as $name => $value) {
-    $mpdf->$name = $value;
-  }
+if (array_key_exists('mpdf', $config)) {
+    foreach ($config['mpdf'] as $name => $value) {
+        $mpdf->$name = $value;
+    }
 }
 
 $mpdf->bleedMargin = $config["config"]["settings"]["bleed_size"];
@@ -64,38 +64,38 @@ $mpdf->bleedMargin = $config["config"]["settings"]["bleed_size"];
 $mpdf->h2toc = array();
 
 // Generate PDF bookmarks from H elements
-$mpdf->h2bookmarks = array('H1'=>0, 'H2'=>1, 'H3'=>2);
+$mpdf->h2bookmarks = array('H1' => 0, 'H2' => 1, 'H3' => 2);
 
 /* Add Styling */
-if(file_exists($options["dir"]."/style.css")) {
-    $css_data = file_get_contents($options["dir"]."/style.css");
+if (file_exists($options["dir"] . "/style.css")) {
+    $css_data = file_get_contents($options["dir"] . "/style.css");
     $mpdf->WriteHTML($css_data, 1);
 }
 
 /* Add Frontmatter */
-if(file_exists($options["dir"]."/frontmatter.html")) {
-   $frontmatter_data = file_get_contents($options["dir"]."/frontmatter.html");
-   $frontmatter_data = strtr($frontmatter_data, array('{TITLE}' => $config['metadata']['title']));
+if (file_exists($options["dir"] . "/frontmatter.html")) {
+    $frontmatter_data = file_get_contents($options["dir"] . "/frontmatter.html");
+    $frontmatter_data = strtr($frontmatter_data, array('{TITLE}' => $config['metadata']['title']));
 
-   $mpdf->WriteHTML($frontmatter_data, 2);
+    $mpdf->WriteHTML($frontmatter_data, 2);
 }
 
 $mpdf->WriteHTML($html, 2);
 
 /* Add Endmatter */
-if(file_exists($options["dir"]."/endmatter.html")) {
-   $data = file_get_contents($options["dir"]."/endmatter.html");
-   $mpdf->WriteHTML($data, 2);
+if (file_exists($options["dir"] . "/endmatter.html")) {
+    $data = file_get_contents($options["dir"] . "/endmatter.html");
+    $mpdf->WriteHTML($data, 2);
 }
 
-if(array_key_exists('title', $config['metadata'])) {
-    if(isset($config['metadata']['title'])) {
+if (array_key_exists('title', $config['metadata'])) {
+    if (isset($config['metadata']['title'])) {
         $mpdf->SetTitle($config['metadata']['title']);
     }
 }
 
-if(array_key_exists('creator', $config['metadata'])) {
-    if(isset($config['metadata']['creator'])) {
+if (array_key_exists('creator', $config['metadata'])) {
+    if (isset($config['metadata']['creator'])) {
         $mpdf->SetAuthor($config['metadata']['creator']);
     }
 }
@@ -105,7 +105,5 @@ $mpdf->InsertIndex(1, 1);
 $mpdf->SetCreator('Booktype');
 
 $mpdf->Output($file_output);
-echo '{"status": 1, "pages": '.$mpdf->page.'}';
+echo '{"status": 1, "pages": ' . $mpdf->page . '}';
 exit;
-?>
-


### PR DESCRIPTION
hi @danielhjames this might be of interest for you, now we can put mpdf configuration options in the theme info.json file. Something like this will work now:

```json
{
 "version": "0.1",
 "name": "Academic",
 "output": {
   "mpdf": {
     "options": {
        "useSubstitutions": true,
        "mirrorMargins": false,
        "h2bookmarks": {"H1": 0, "H2": 1, "H3": 2}
      },
     "frontmatter": "frontmatter_mpdf.html",
     "endmatter": "endmatter_mpdf.html",
     "body": "body_mpdf.html"
   }
}
```
This will also work for screenpdf.