### PR TITLE
BK-1897 Correct language code for Norwegian Bokmål

### DIFF
--- a/lib/booktype/skeleton/base_settings.py.original
+++ b/lib/booktype/skeleton/base_settings.py.original
@@ -150,7 +150,7 @@ LANGUAGES = (
    ('ko', gettext('한국어')),
    ('hu', gettext('Magyar')),
    ('nl', gettext('Nederlands')),
-   ('no', gettext('Norsk (Bokmål)')),
+   ('nb', gettext('Norsk (Bokmål)')),
    ('pl', gettext('Polski')),
    ('pt', gettext('Português')),
    ('ru', gettext('Русский')),


### PR DESCRIPTION
Django only supports the nb code, see https://code.djangoproject.com/ticket/11068