### PR TITLE
BK-1971 Select-all functionality does not work sometimes when multiple Aloha-blocks

### DIFF
--- a/lib/booktype/apps/edit/static/edit/js/aloha/plugins/booktype/shortcuts/lib/shortcuts-plugin.js
+++ b/lib/booktype/apps/edit/static/edit/js/aloha/plugins/booktype/shortcuts/lib/shortcuts-plugin.js
@@ -11,13 +11,13 @@ define([
       selectAll: function (event, editor) {
         var el = editor;
         var start = getFirstSelectableChild(el);
-        var endOffset = el.childNodes ? el.childNodes.length : el.length;
+        var end = getLastSelectableChild(el);
 
         CopyPaste.setSelectionAt({
           startContainer: start,
-          endContainer: el,
+          endContainer: end,
           startOffset: 0,
-          endOffset: endOffset
+          endOffset: end.length
         });
 
         return false;
@@ -119,6 +119,35 @@ define([
               }
             } else {
               child = child.nextSibling;
+            }
+          }
+        } else {
+          // Given element is a text node so return it.
+          return element;
+        }
+      }
+      return null;
+    }
+
+    function getLastSelectableChild(element) {
+      var TEXT_NODE = 3;
+
+      if (element) {
+        if (element.nodeType !== TEXT_NODE) {
+          var child = element.lastChild;
+          while (child) {
+            if (isSelectable(child) === true) {
+              return child;
+            } else if (child.lastChild) {
+              // This node does have child nodes.
+              var res = getLastSelectableChild(child);
+              if (res !== null) {
+                return res;
+              } else {
+                child = child.previousSibling;
+              }
+            } else {
+              child = child.previousSibling;
             }
           }
         } else {


### PR DESCRIPTION
Hi @aerkalov, I created this little PR because I found that select-all function does not work sometimes when having a lot of aloha blocks in the editor. Take a look of it please :)