### PR TITLE
BK-1990 Get PUBLISH_OPTIONS base settings in sync with constants

### DIFF
--- a/lib/booktype/skeleton/base_settings.py.original
+++ b/lib/booktype/skeleton/base_settings.py.original
@@ -24,9 +24,9 @@ EXPORT_ALLOWED_HOSTS = ['127.0.0.1']
 
 DEFAULT_NOTIFICATION_FILTER=u"#* !* ~* \u212c*"
 
-# You can customize which publish options this installation can use.
-# Options are: book, ebook, pdf, lulu, odt
-# PUBLISH_OPTIONS = ("book", "ebook")
+# You can customize the default publishing options this instance can use.
+# Options are: mpdf, screenpdf, epub, mobi, xhtml
+# PUBLISH_OPTIONS = ("mpdf", "screenpdf", "epub")
 
 # BOOKTYPE
 PROFILE_ACTIVE = ''


### PR DESCRIPTION
lib/booktype/constants.py says:

PUBLISH_OPTIONS = ['mpdf', 'screenpdf', 'epub', 'mobi', 'xhtml']