### PR TITLE
BK-2032 Some fileupload listeners attached to the whole document

### DIFF
--- a/lib/booktype/apps/account/static/account/js/dashboard.js
+++ b/lib/booktype/apps/account/static/account/js/dashboard.js
@@ -191,27 +191,25 @@
         return true;
       };
 
+      $(document).bind('drop dragover dragenter', function (e) {
+        e.preventDefault();
+      });
+
       $(document).on('dragenter dragover', '#drag-area', function (e) {
         e.stopPropagation();
         e.preventDefault();
       });
 
-      $(document).on('drop', '#drag-area', function (e) {
-        e.preventDefault();
-        var files = e.originalEvent.dataTransfer.files;
-
-        // set file to input field to then send the file to server
-        $('#book-file').data('files', files);
-      });
-
       var importButton = $('#import');
       var congratsMsg = $('.congrats');
+      var dragArea = $('#drag-area');
 
       // jquery fileupload
       $('#book-file').fileupload({
         dataType: 'json',
         sequentialUploads: true,
-
+        dropZone: dragArea,
+        pasteZone: dragArea,
         done: function (e, data) {
           var result = data.result;
 

--- a/lib/booktype/apps/edit/static/edit/js/aloha/plugins/booktype/imagesimple/lib/imagesimple-plugin.js
+++ b/lib/booktype/apps/edit/static/edit/js/aloha/plugins/booktype/imagesimple/lib/imagesimple-plugin.js
@@ -300,12 +300,19 @@ define(['aloha', 'aloha/plugin', 'jquery', 'jquery19', 'ui/ui', 'aloha/console',
         $manager = jQuery19(document).find('#imageManager');
         $popup = jQuery19('#imagePopup');
 
+
         BlockManager.registerBlockType('ImageBlock', ImageBlock.ImageBlock);
         var alertWrapper = jQuery19('.alert-wrapper');
+
+        $(document).bind('drop dragover dragenter', function (e) {
+          e.preventDefault();
+        });
 
         jQuery19('.upload-file', $manager).fileupload({
           dataType: 'json',
           sequentialUploads: true,
+          dropZone: jQuery19('#imageManager .drag-area'),
+          pasteZone: jQuery19('#imageManager .drag-area'),
           done: function (e, data) {
             reloadAttachments(function () {
               jQuery19('a.medialibrary', $manager).tab('show');

--- a/lib/booktype/apps/edit/static/edit/js/booktype/covers.js
+++ b/lib/booktype/apps/edit/static/edit/js/booktype/covers.js
@@ -243,7 +243,7 @@
       loadCovers();
 
       fileUpload = null;
-      jquery('#fileupload').fileupload({
+      jquery('#cover_fileupload').fileupload({
         dataType: 'json',
         sequentialUploads: true,
         done: function (e, data) {

--- a/lib/booktype/apps/edit/static/edit/js/booktype/media.js
+++ b/lib/booktype/apps/edit/static/edit/js/booktype/media.js
@@ -135,7 +135,7 @@
       jquery('span.cancel-upload').fadeOut(function () {
         jquery('DIV.contentHeader .progress-bar').css('width', '0%');
       });
-      jquery('#fileupload').prop('disabled', false);
+      jquery('#media_fileupload').prop('disabled', false);
     };
 
     var _show = function () {
@@ -195,7 +195,7 @@
       });
 
       fileUpload = null;
-      jquery('#fileupload').fileupload({
+      jquery('#media_fileupload').fileupload({
         dataType: 'json',
         sequentialUploads: true,
         done: function (e, data) {
@@ -218,7 +218,7 @@
             if (win.booktype.utils.isUploadAllowed(fileName)) {
               jquery('#progress').show();
               jquery('span.cancel-upload').show();
-              jquery('#fileupload').prop('disabled', true);
+              jquery('#media_fileupload').prop('disabled', true);
 
               fileUpload = data.submit();
             } else {

--- a/lib/booktype/apps/edit/templates/edit/panel_covers.html
+++ b/lib/booktype/apps/edit/templates/edit/panel_covers.html
@@ -20,7 +20,7 @@
         <span class="btn btn-success fileinput-button">
             <i class="icon-plus icon-white"></i>
             <span>{% trans "Upload cover" %}</span>
-            <input id="fileupload" type="file" name="files[]"  data-url="../_upload_cover/">
+            <input id="cover_fileupload" type="file" name="files[]"  data-url="../_upload_cover/">
         </span>
       </div>
       {% endcheck_perm %}

--- a/lib/booktype/apps/edit/templates/edit/panel_media.html
+++ b/lib/booktype/apps/edit/templates/edit/panel_media.html
@@ -13,7 +13,7 @@
       <span class="btn btn-success fileinput-button">
           <i class="icon-plus icon-white"></i>
           <span>{% trans "Add files..." %}</span>
-          <input id="fileupload" type="file" name="files[]" multiple data-url="../_upload/">
+          <input id="media_fileupload" type="file" name="files[]" multiple data-url="../_upload/">
       </span>
       {% endcheck_perm %}
     </div>


### PR DESCRIPTION
Hi, Helmy.

This pr is kinda fix for all places (import book popup, image gallery in the editor, media and cover tabs) where we have ability upload image using dragndrop from file manager.
Right now, it is possible to move/drag/drop image/file to any area of the whole website, which is wrong. 
Also I found html elements with the same id on one page :) This was also fixed, but in requires template/js update for custom instances in case if they were overloaded.