### PR TITLE
BK-2034 Create ability to control permissions from JS app

### DIFF
--- a/lib/booktype/apps/edit/channel.py
+++ b/lib/booktype/apps/edit/channel.py
@@ -342,18 +342,32 @@ def remote_init_editor(request, message, bookid, version):
         theme.save()
         theme_active = ''
 
+    # provide information about current user
+    current_user = {
+        'username': book_security.user.username,
+        'first_name': book_security.user.first_name,
+        'last_name': book_security.user.last_name,
+        'email': book_security.user.email,
+        'is_superuser': book_security.is_superuser(),
+        'is_staff': book_security.is_staff(),
+        'is_admin': book_security.is_admin(),
+        'is_book_owner': book_security.is_book_owner(),
+        'is_book_admin': book_security.is_book_admin(),
+        'permissions': ['{0}.{1}'.format(perm.app_name, perm.name) for perm in book_security.permissions],
+    }
+
     return {"licenses": licenses,
             "chapters": chapters,
             "metadata": metadata,
             "hold": hold_chapters,
             "users": users,
-            "is_admin": book_security.is_admin(),
             "statuses": statuses,
             "attachments": attachments,
             "theme": theme_active,
             # Check for errors in the future
             "theme_custom": json.loads(theme.custom),
-            "onlineUsers": list(onlineUsers)}
+            "onlineUsers": list(onlineUsers),
+            "current_user": current_user}
 
 
 def remote_attachments_list(request, message, bookid, version):

--- a/lib/booktype/apps/edit/static/edit/js/booktype/editor.js
+++ b/lib/booktype/apps/edit/static/edit/js/booktype/editor.js
@@ -677,6 +677,20 @@
 
       win.booktype.sendToCurrentBook({'command': 'init_editor'},
         function (dta) {
+          // init current user object
+          win.booktype.currentUser = new data.panels.toc.User({
+            username: dta.current_user.username,
+            firstName: dta.current_user.first_name,
+            lastName: dta.current_user.last_name,
+            email: dta.current_user.email,
+            isSuperuser: dta.current_user.is_superuser,
+            isStaff: dta.current_user.is_staff,
+            isAdmin: dta.current_user.is_admin,
+            isBookOwner: dta.current_user.is_book_owner,
+            isBookAdmin: dta.current_user.is_book_admin,
+            permissions: dta.current_user.permissions
+          });
+
           // Put this in the TOC
           data.chapters.clear();
           data.chapters.loadFromArray(dta.chapters);
@@ -717,6 +731,20 @@
 
       win.booktype.sendToCurrentBook({'command': 'init_editor'},
         function (dta) {
+          // init current user object
+          win.booktype.currentUser = new data.panels.toc.User({
+            username: dta.current_user.username,
+            firstName: dta.current_user.first_name,
+            lastName: dta.current_user.last_name,
+            email: dta.current_user.email,
+            isSuperuser: dta.current_user.is_superuser,
+            isStaff: dta.current_user.is_staff,
+            isAdmin: dta.current_user.is_admin,
+            isBookOwner: dta.current_user.is_book_owner,
+            isBookAdmin: dta.current_user.is_book_admin,
+            permissions: dta.current_user.permissions
+          });
+
           // Put this in the TOC
           data.chapters.clear();
           data.chapters.loadFromArray(dta.chapters);

--- a/lib/booktype/apps/edit/static/edit/js/booktype/toc.js
+++ b/lib/booktype/apps/edit/static/edit/js/booktype/toc.js
@@ -211,6 +211,43 @@
     };
 
     /*******************************************************************************/
+    /* USER                                                                        */
+    /*******************************************************************************/
+
+    var User = Backbone.Model.extend({
+      defaults: {
+        username: "",
+        firstName: "",
+        lastName: "",
+        email: "",
+        isSuperuser: false,
+        isStaff: false,
+        isAdmin: false,
+        isBookOwner: false,
+        isBookAdmin: false,
+        permissions: []
+      },
+      hasPerm: function (perm) {
+        /**
+         Check user permissions.
+         This method will also check if user is admin. In case
+         user is admin, it will get any kind of permissions they ask for.
+
+         :Example:
+         window.booktype.currentUser.hasPerm('edit.add_comment')
+
+         :Args:
+         - perm (:class:`string`): permission to check for in {app_name}.{perm_name} format
+
+         :Returns:
+         true or false.
+         */
+
+        return this.get("isAdmin") === true || _.indexOf(this.get("permissions"), perm) !== -1;
+      }
+    });
+
+    /*******************************************************************************/
     /* CHAPTER                                                                     */
     /*******************************************************************************/
 
@@ -1470,6 +1507,7 @@
       },
       "TOC": TOC,
       "Chapter": Chapter,
+      "User": User,
 
       "doRenameChapter": _doRenameChapter,
       "doRenameSection": _doRenameSection,

--- a/lib/booktype/apps/edit/templates/edit/edit_config.html
+++ b/lib/booktype/apps/edit/templates/edit/edit_config.html
@@ -1,4 +1,5 @@
 <script type="text/javascript">
+      window.booktype.currentUser = null;
       window.booktype.username = "{{ request.user.username|escapejs }}";
       window.booktype.email = "{{ request.user.email|escapejs }}";
       window.booktype.fullname = "{{ request.user.first_name|escapejs }}";


### PR DESCRIPTION
We have good tools to control user permissions on the backend part, but we can't control them from JS app (editor). Now we check permissions by rendering or not rendering something in the templates, and it works just fine, but in some cases we need this logic on the JS level, for example in comments/component.jsx or other aloha plugins.

This user backbone model `var User = Backbone.Model.extend({....` is book oriented, it kinda repeats `BookSecurity(Security):` we have on python's level.

This pr provides next permission check:
`window.booktype.editor.data.currentUser.hasPerm('edit.add_comment')`

