### PR TITLE
BK-2125 Create epub converter plugin to drop not allowed tags

### DIFF
--- a/lib/booktype/constants.py
+++ b/lib/booktype/constants.py
@@ -103,6 +103,26 @@ XHTML_DOCUMENT_WIDTH = 2480
 MOBI_DOCUMENT_WIDTH = 2480
 EPUB_DOCUMENT_WIDTH = 2480
 
+EPUB_NOT_ALLOWED_TAGS = (
+    # 'strip' - drop tag, leave content
+    # 'drop' - drop tag, drop content
+    # 'replace' - replace tag with 'replacement'
+    # EXAMPLES:
+    # {'tag': 'i', 'action': 'strip'},
+    # {'tag': 'b', 'action': 'drop'},
+    # {
+    #     'tag': 'u',
+    #     'action': 'replace',
+    #     'replacement': {
+    #         'tag': 'span',
+    #         'attrs': (
+    #             ('style', 'text-decoration: underline;'),
+    #             ('class', 'happy'),
+    #         )
+    #     }
+    # },
+)
+
 EXPORT_SETTINGS = {
     'mpdf': [
         {u'name': u'size', u'value': u'A4'}, {u'name': u'custom_width', u'value': u''},

--- a/lib/booktype/convert/epub/constants.py
+++ b/lib/booktype/convert/epub/constants.py
@@ -13,3 +13,5 @@ EPUB_VALID_IMG_ATTRS = frozenset([
 ])
 
 EPUB_DOCUMENT_WIDTH = config.get_configuration('EPUB_DOCUMENT_WIDTH')
+
+EPUB_NOT_ALLOWED_TAGS = config.get_configuration('EPUB_NOT_ALLOWED_TAGS')

--- a/lib/booktype/convert/epub/converter.py
+++ b/lib/booktype/convert/epub/converter.py
@@ -36,17 +36,17 @@ from booktype.apps.convert.templatetags.convert_tags import (
 from booktype.apps.convert import plugin
 from booktype.convert.image_editor_conversion import ImageEditorConversion
 
-from ..base import BaseConverter
-from ..utils.epub import parse_toc_nav
-
 from .writer import Writer
-from .writerplugin import WriterPlugin
-from .image_editor_writerplugin import ImageEditorWriterPlugin
+from .writerplugins import WriterPlugin, ImageEditorWriterPlugin, CleanupTagsWriterPlugin
+
 from .cover import add_cover, COVER_FILE_NAME
 from .constants import (
     IMAGES_DIR, STYLES_DIR, FONTS_DIR,
     DOCUMENTS_DIR, DEFAULT_LANG, EPUB_DOCUMENT_WIDTH
 )
+
+from ..base import BaseConverter
+from ..utils.epub import parse_toc_nav
 
 logger = logging.getLogger("booktype.convert.epub")
 
@@ -207,8 +207,9 @@ class EpubConverter(BaseConverter):
 
         writer_plugin = self._get_writer_plugin(epub_book, original_book)
         image_editor_writer_plugin = ImageEditorWriterPlugin(self.config.get("project_id"))
+        cleanup_tags_writerplugin = CleanupTagsWriterPlugin()
 
-        return [writer_plugin, image_editor_writer_plugin]
+        return [writer_plugin, image_editor_writer_plugin, cleanup_tags_writerplugin]
 
     def _get_writer_class(self):
         """Simply returns the default writer class to be used by the converter"""

--- a/lib/booktype/convert/epub/writerplugins/__init__.py
+++ b/lib/booktype/convert/epub/writerplugins/__init__.py
@@ -1,0 +1,3 @@
+from .base_writerplugin import WriterPlugin
+from .image_editor_writerplugin import ImageEditorWriterPlugin
+from .cleanup_tags_writerplugin import CleanupTagsWriterPlugin

--- a/lib/booktype/convert/epub/writerplugins/base_writerplugin.py
+++ b/lib/booktype/convert/epub/writerplugins/base_writerplugin.py
@@ -7,8 +7,8 @@ import ebooklib
 from lxml import etree
 from ebooklib.plugins.base import BasePlugin
 
-from ..utils.epub import reformat_endnotes
-from .constants import (
+from booktype.convert.utils.epub import reformat_endnotes
+from ..constants import (
     STYLES_DIR, IMAGES_DIR,
     DEFAULT_LANG, EPUB_VALID_IMG_ATTRS
 )

--- a/lib/booktype/convert/epub/writerplugins/cleanup_tags_writerplugin.py
+++ b/lib/booktype/convert/epub/writerplugins/cleanup_tags_writerplugin.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+import ebooklib
+
+from lxml import etree
+from lxml.etree import strip_tags, strip_elements
+from ebooklib.plugins.base import BasePlugin
+
+from ..constants import EPUB_NOT_ALLOWED_TAGS
+
+
+class CleanupTagsWriterPlugin(BasePlugin):
+    """Cleanup plugin for Booktype EPUB Writing"""
+
+    def _cleanup(self, root):
+        for tag, action, replacement in [
+            (i['tag'], i['action'], i['replacement'] if 'replacement' in i else None) for i in EPUB_NOT_ALLOWED_TAGS
+            ]:
+            if action == 'strip':
+                for element in root.iter('p'):
+                    strip_tags(element, tag)
+            elif action == 'drop':
+                for element in root.iter('p'):
+                    strip_elements(element, tag, with_tail=False)
+            elif action == 'replace':
+                for element in root.iter(tag):
+                    element.tag = replacement['tag']
+                    element.attrib.clear()
+
+                    for attrib, content in replacement['attrs']:
+                        element.set(attrib, content)
+            else:
+                raise Exception('EPUB_NOT_ALLOWED_TAGS contains not allowed actions.')
+
+
+    def html_before_write(self, book, item):
+        if item.get_type() != ebooklib.ITEM_DOCUMENT:
+            return True
+
+        if isinstance(item, ebooklib.epub.EpubNav):
+            return True
+
+        root = ebooklib.utils.parse_html_string(item.content)
+        self._cleanup(root)
+        item.content = etree.tostring(root, pretty_print=True, encoding="utf-8", xml_declaration=True)
+
+        return True

--- a/lib/booktype/convert/epub/writerplugins/image_editor_writerplugin.py
+++ b/lib/booktype/convert/epub/writerplugins/image_editor_writerplugin.py
@@ -10,9 +10,7 @@ from ebooklib.plugins.base import BasePlugin
 from django.conf import settings
 
 from booktype.utils.image_editor import BkImageEditor
-
-from .constants import IMAGES_DIR
-
+from ..constants import IMAGES_DIR
 
 try:
     import Image


### PR DESCRIPTION
Hi @eos87 , please check the PR.

I also moved writerplugins to the separate folder to have better file organisation in epub converter.
it can brake some instances, because import link to the WriterPlugin was changed from
`from .writerplugin import WriterPlugin` to `from .writerplugins import WriterPlugin`.

Just FYI, epub2 does not support `<u>` (underline) tag, epubcheck complains about it. 
With **this** plugin, we can also do replace, for example here configuration I have in **configuration.json** file for instance which has epub2 output:

```
"EPUB_NOT_ALLOWED_TAGS": [
    {
      "tag": "u",
      "action": "replace",
      "replacement": {
        "tag": "span",
        "attrs": [
          [
            "style",
            "text-decoration: underline;"
          ]
        ]
      }
    }
  ]
```

it will find and convert `<u>TEXT</u>` to `<span style="text-decoration: underline;">TEXT</span>`
which is ok for epub2.
