### PR TITLE
BTCAMN-34 Increase default autosave time to 60 seconds

### DIFF
--- a/lib/booktype/apps/edit/static/edit/js/booktype/editor.js
+++ b/lib/booktype/apps/edit/static/edit/js/booktype/editor.js
@@ -79,7 +79,7 @@
           },
           'autosave': {
             'enabled': true,
-            'delay': 10
+            'delay': 60
           }
         },
         'media': {


### PR DESCRIPTION
User feedback indicates that 10 seconds is too short to think about using the existing Save and Save with comment features, and then it is too late to create a new revision. 