### PR TITLE
BK-2215 DOCX import modal: append and overwrite same colour

### DIFF
--- a/lib/booktype/apps/core/static/core/js/booki.js
+++ b/lib/booktype/apps/core/static/core/js/booki.js
@@ -720,7 +720,7 @@
       },
 
       confirm: function (params, callback) {
-        var confirm = win.booktype.ui.getTemplate('templateAlertModal');
+        var confirm = params.customTemplate || win.booktype.ui.getTemplate('templateAlertModal');
 
         win.booktype.ui.fillTemplate(confirm, {
           'message': params.message,

--- a/lib/booktype/apps/edit/static/edit/js/booktype/toc.js
+++ b/lib/booktype/apps/edit/static/edit/js/booktype/toc.js
@@ -658,6 +658,13 @@
 
         uploadDocxForm.attr('action', actionUrl);
 
+        // custom template to avoid more html and have custom buttons
+        var alertTemplate = $('.template.templateAlertModal').clone().removeClass('template');
+        var overrideBtn = alertTemplate.find('.btn.btn-default');
+        overrideBtn
+          .removeClass('btn-default')
+          .addClass('btn-primary');
+
         var importCallback = function (mode) {
           var importMode = mode ? "overwrite" : "append";
           uploadDocxForm.find('input[name=import_mode]').val(importMode)
@@ -672,7 +679,8 @@
           width: 370,
           acceptText: win.booktype._('append_label'),
           cancelText: win.booktype._('overwrite_label'),
-          showCloseButton: true
+          showCloseButton: true,
+          customTemplate: alertTemplate
         }, importCallback);
       });
 


### PR DESCRIPTION
Small commit just to make both buttons same colour on import docx dialog, both should be orange. This also allows the util function `confirm` to receive an extra param to specify a custom template for the `alert/dialog`