### PR TITLE
BK-2263 Add ability to view log files from django admin

### DIFF
--- a/lib/booktype/skeleton/base_settings.py.original
+++ b/lib/booktype/skeleton/base_settings.py.original
@@ -244,6 +244,7 @@ INSTALLED_APPS = (
 
     'compressor',
     'djcelery',
+    'logtailer',
     'rest_framework',
     'rest_framework.authtoken',
     'rest_framework_swagger',

--- a/lib/booktype/urls.py
+++ b/lib/booktype/urls.py
@@ -30,6 +30,9 @@ SPUTNIK_DISPATCHER = (
 )
 
 urlpatterns = [
+    # django log tailer
+    url(r'^_logs/', include('logtailer.urls')),
+
     # internationalization
     url(r'^_i18n/', include('django.conf.urls.i18n')),
 

--- a/requirements/_base.txt
+++ b/requirements/_base.txt
@@ -14,5 +14,6 @@ django-rest-swagger==2.1.0
 djangorestframework==3.5.3
 Markdown==2.6.7
 django-filter==1.0.0
+django-logtailer==1.0.1
 
 -e git+git://github.com/aerkalov/ebooklib.git#egg=EbookLib


### PR DESCRIPTION
Hi @eos87 ,
Check this PR. I've added https://github.com/fireantology/django-logtailer for our django admin. 
I put it into base settings and global urls, it means that this feature will be available for dev, stage and prod profiles. In general for production instances it's not very useful, because **www-data** doe's not have access to let's say apache/supervisor logs, but we still have access to the normal instance's logs folder.  It will be useful for stage instances as well. It will simplify our live at some point, so you don't need to do ssh just for reading logs. 
P.S. Currently it works similar to `tail -f`, it reads and shows updates. I checked library and it seems like it's possible to adjust it a little bit and have ability to read logs fully.
🍺 🍻 :man_technologist: 