### PR TITLE
BK-2278 Modal dialogs with data-remote are not working

### DIFF
--- a/lib/booktype/apps/account/static/account/js/dashboard.js
+++ b/lib/booktype/apps/account/static/account/js/dashboard.js
@@ -93,11 +93,6 @@
         $('#books-prew, #books-prew-2').attr('class', 'book-thumb');
       });
 
-      // add fade class when opening from button
-      $(document).on('click', '#create-group-btn', function () {
-        $('#createGroupModal').addClass('fade');
-      });
-
       // bind keydown on title field to check book name availability
       $(document).on('keydown input', '.modal-dialog.new_book input[name="title"]', function () {
         win.booktype.initCSRF();
@@ -335,7 +330,6 @@
         },
 
         createGroup: function () {
-          $('#createGroupModal').removeClass('fade');
           $('#create-group-btn').trigger('click');
         }
       });

--- a/lib/booktype/apps/core/static/core/js/booktype.js
+++ b/lib/booktype/apps/core/static/core/js/booktype.js
@@ -47,5 +47,17 @@
       $(this).removeData('bs.modal').html('');
     });
 
+    // Loading modal's content from a remote address was deprecated in bootstrap 3.3
+    // so, we need to trick this out a bit to keep working with the current
+    // logic which was just fine.
+    $(document).on('click', '[data-toggle=modal][data-remote]', function (){
+      var target = $(this).data('target');
+      var url = $(this).data('remote');
+
+      $(target)
+        .load(url)
+        .modal('show');
+    })
+
   });
 })(window, jQuery);


### PR DESCRIPTION
Loading modal's content from a remote address was deprecated in bootstrap 3.3 so, this adds the ability to keep using modals loading their content from remote urls :)