### PR TITLE
BK-2287 Add ability to provide custom crop margin size for mpdf converter

### DIFF
--- a/lib/booktype/constants.py
+++ b/lib/booktype/constants.py
@@ -202,7 +202,8 @@ EXPORT_SETTINGS = {
         {u'name': u'gutter', u'value': u'20'}, {u'name': u'show_header', u'value': u'on'},
         {u'name': u'header_margin', u'value': u'10'}, {u'name': u'show_footer', u'value': u'on'},
         {u'name': u'footer_margin', u'value': u'10'}, {u'name': u'bleed_size', u'value': u''},
-        {u'name': u'styling', u'value': u''}, {u'name': u'crop_marks', u'value': u'off'}],
+        {u'name': u'styling', u'value': u''},
+        {u'name': u'crop_marks', u'value': u'off'}, {u'name': u'crop_margin', u'value': u'18'}],
     'screenpdf': [
         {u'name': u'size', u'value': u'A4'}, {u'name': u'custom_width', u'value': u''},
         {u'name': u'custom_height', u'value': u''}, {u'name': u'top_margin', u'value': u'20'},

--- a/lib/booktype/convert/mpdf/converter.py
+++ b/lib/booktype/convert/mpdf/converter.py
@@ -126,17 +126,16 @@ class MPDFConverter(BaseConverter):
         # Not that much needed at the moment
         self.config['page_width'], self.config['page_height'] = get_page_size(self.config['settings'])
 
-        try:
-            if 'crop_marks' in self.config['settings'] and self.config['settings']['crop_marks'] == 'on':
-                crop_margin = CROP_MARGIN
-            else:
-                crop_margin = 0
+        # if crop marks is enabled
+        if 'crop_marks' in self.config['settings'] and self.config['settings']['crop_marks'] == 'on':
+            crop_margin = CROP_MARGIN
 
-            self.config['page_width_bleed'] = int(round(self.config['page_width'] + crop_margin))
-            self.config['page_height_bleed'] = int(round(self.config['page_height'] + crop_margin))
-        except Exception as e:
-            logger.error('MPDF::pre_convert: {}'.format(e))
+            if 'crop_margin' in self.config['settings']:
+                crop_margin = int(self.config['settings']['crop_margin'])
 
+            self.config['page_width_bleed'] = self.config['page_width'] + crop_margin
+            self.config['page_height_bleed'] = self.config['page_height'] + crop_margin
+        else:
             self.config['page_width_bleed'] = self.config['page_width']
             self.config['page_height_bleed'] = self.config['page_height']
 


### PR DESCRIPTION
- simplified logic
- removed try/except, if error happens it means that we have wrong settings
- add ability to select custom crop margin using `crop_margin` export settings
- added `crop_margin` to the default export settings just to show that this option exists