### PR TITLE
BK-2294 Don't edit images for ICML output

### DIFF
--- a/lib/booktype/convert/pandoc/icml/converter.py
+++ b/lib/booktype/convert/pandoc/icml/converter.py
@@ -5,6 +5,7 @@ from unipath import Path
 from django.conf import settings
 
 from ...epub.writerplugins import CleanupTagsWriterPlugin
+from ...epub.converter import Epub3Converter
 from ...utils import run_command
 from ..base_pandoc_converter import BasePandocConverter
 from ..writerplugins import RawifiedImagesWriterPlugin
@@ -21,6 +22,15 @@ class ICMLConverter(BasePandocConverter):
     """
 
     name = 'icml'
+
+    def pre_convert(self, original_book, book):
+        super(Epub3Converter, self).pre_convert(original_book)
+
+        if self.theme_plugin:
+            try:
+                self.theme_plugin.pre_convert(original_book, book)
+            except NotImplementedError:
+                pass
 
     def _get_plugins(self, epub_book, original_book):
         """Returns the plugins to be used by writer instance"""

--- a/lib/booktype/utils/image_editor.py
+++ b/lib/booktype/utils/image_editor.py
@@ -147,7 +147,11 @@ class BkImageEditor(object):
 
         # cache folder
         if not os.path.exists(self._cache_folder):
-            os.makedirs(self._cache_folder)
+            # folder can be created by another process between os.path.exists and os.makedirs
+            try:
+                os.makedirs(self._cache_folder)
+            except OSError:
+                pass
 
         if self.USE_CACHE:
             if os.path.exists(output_filepath):


### PR DESCRIPTION
PR also contains one tiny update for image editor cache folder.
`# folder can be created by another process between os.path.exists and os.makedirs`