### PR TITLE
BK-2343 Collect additional metadata for PDF generation

### DIFF
--- a/lib/booktype/skeleton/base_settings.py.original
+++ b/lib/booktype/skeleton/base_settings.py.original
@@ -485,6 +485,22 @@ TEST_RUNNER = 'django.test.runner.DiscoverRunner'
 # )
 
 _ADDITIONAL_METADATA = [
+    ('meta_subject', {
+        'TYPE': 'CharField',
+        'ATTRS': {
+            'required': False,
+            'label': 'Subject'
+            },
+        'WIDGET': 'TextInput'
+    }),
+    ('meta_keywords', {
+        'TYPE': 'CharField',
+        'ATTRS': {
+            'required': False,
+            'label': 'Keywords'
+            },
+        'WIDGET': 'TextInput'
+    }),
     ('edited_by', {
         'TYPE': 'CharField',
         'ATTRS': {


### PR DESCRIPTION
PDF readers support subject and keyword metadata but we don't currently collect it. These values could then be used in templates.