### PR TITLE
Avoid splitting translations strings to enable other word orders

### DIFF
--- a/lib/booktype/apps/account/templates/account/dashboard_create_book_modal.html
+++ b/lib/booktype/apps/account/templates/account/dashboard_create_book_modal.html
@@ -116,7 +116,7 @@
                     <p>
                       {% trans "No book skeletons yet." %}
                       {% check_perm 'account.can_manage_book_skeletons' %}
-                      {% trans "You can manage them from the" %} <a href="{% url 'control_center:settings' %}#list-of-skeletons">{% trans "Control Center" %}</a>
+                      {% blocktrans %}You can manage book skeletons from the <a href="{% url 'control_center:settings' %}#list-of-skeletons">Control Center</a>.{% endblocktrans %}
                       {% endcheck_perm %}
                     </p>
                   </div>

--- a/lib/booktype/apps/edit/templates/edit/panel_settings.html
+++ b/lib/booktype/apps/edit/templates/edit/panel_settings.html
@@ -135,8 +135,7 @@
     {% trans "Roles" %}
   </h4>
   <div class="roles">
-    {% trans "This book doesn't contain invited people. Please invite people in your " %}
-    <a target="_blank" href="{% url "accounts:view_profile" request.user.username %}">{% trans "Dashboard" %}</a>.
+    {% blocktrans %}This book doesn't have any invited people. You can invite people from your <a target="_blank" href="{% url "accounts:view_profile" request.user.username %}">Dashboard</a>.{% endblocktrans %}
   </div>
 </script>
 
@@ -145,7 +144,7 @@
     <div class="modal-content">
       <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
-        <h3>{% trans "Change roles for " %}<span></span></h3>
+        <h3>{% blocktrans %}Change roles for <span>{{ username }}</span>{% endblocktrans %}</h3>
       </div>
       <div class="modal-body">
         <div class="roles-options"></div>


### PR DESCRIPTION
Please review, I'm not sure about how to fix the 'Change roles for' string.