### PR TITLE
BK-2368 Sections settings exported incorrectly when empty sections exists

### DIFF
--- a/lib/booktype/apps/convert/plugin.py
+++ b/lib/booktype/apps/convert/plugin.py
@@ -186,6 +186,7 @@ class TocSettings(object):
     HIDE_SECTION_SHOW_CHAPTERS = 'hide_section_show_chapters'
     HIDE_SECTION_HIDE_CHAPTERS = 'hide_section_hide_chapters'
 
+
 class SectionsSettingsPlugin(BasePlugin):
     """
     Plugin to handle sections settings stuff which would be common for all

--- a/lib/booktype/apps/export/utils.py
+++ b/lib/booktype/apps/export/utils.py
@@ -466,13 +466,14 @@ class ExportBook(object):
           - self (:class:`ExportBook`): current class instance
         """
 
-        from booktype.utils.misc import booktype_slugify
+        from booktype.apps.convert.plugin import SectionsSettingsPlugin
 
         settings = {}
         count = 1
         for item in self.book_version.get_toc():
-            if item.is_section() and item.settings:
-                settings['section_%s_%s' % (booktype_slugify(item.name), count)] = item.settings
+            if item.is_section() and item.has_children() and item.settings:
+                key = SectionsSettingsPlugin.build_section_key(item.name, count)
+                settings[key] = item.settings
                 count += 1
 
         self.epub_book.add_metadata(


### PR DESCRIPTION
This should solve the problem of having empty sections and the
section_count being incremented at the moment of saving settings. We
need to find a better way to create the unique keys instead of using
count which might be a bit unreliable under certain situations