### PR TITLE
BK-2373 Make sure H1 text is black in unified history comparison tables

### DIFF
--- a/lib/booktype/apps/edit/templates/edit/download_history.html
+++ b/lib/booktype/apps/edit/templates/edit/download_history.html
@@ -67,6 +67,9 @@
         .diff.added{
           text-decoration: underline;
         }
+        .compare_table h1{
+          color: #000;
+        }
         </style>
       {% endcompress %}
   </head>


### PR DESCRIPTION
Needed to avoid H1 elements being given the text colour of the user interface.